### PR TITLE
fix: Fix pyproject.toml PEP 639 file reference and bump to v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2025-10-12
+
+### Fixed
+- **pyproject.toml PEP 639 File Reference**: Fixed license detection from `license = {file = "LICENSE"}` format
+  - Changed from non-existent `_detect_license_from_text()` to proper `_detect_from_full_text()` method
+  - Now correctly reads and detects licenses from referenced files in pyproject.toml
+  - Properly sets category as DECLARED for licenses from metadata file references
+  - Added debug logging when referenced license file doesn't exist
+
 ### Removed
 - **Notices Output Format**: Removed human-readable notices format to focus on scanning and verification
   - Removed `notices_formatter.py` module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "semantic-copycat-oslili"
-version = "1.4.0"
+version = "1.4.1"
 description = "Semantic Copycat Open Source License Identification Library"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/semantic_copycat_oslili/__init__.py
+++ b/semantic_copycat_oslili/__init__.py
@@ -13,7 +13,7 @@ if os.environ.get('OSLILI_DEBUG') != '1':
     except ImportError:
         pass
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 from .core.generator import LicenseCopyrightDetector
 from .core.models import (

--- a/semantic_copycat_oslili/detectors/license_detector.py
+++ b/semantic_copycat_oslili/detectors/license_detector.py
@@ -1146,15 +1146,18 @@ class LicenseDetector:
                 try:
                     license_content = self.input_processor.read_text_file(license_file_path)
                     if license_content:
-                        # Detect license from the file content
-                        detected = self._detect_license_from_text(license_content, license_file_path)
-                        if detected:
+                        # Detect license from the file content using Dice-Sørensen with TLSH confirmation
+                        detected_licenses = self._detect_from_full_text(license_content, license_file_path)
+                        for detected in detected_licenses:
                             # Update the source to show it came from pyproject.toml reference
                             detected.source_file = str(file_path)
                             detected.match_type = "package_metadata_file"
+                            detected.category = LicenseCategory.DECLARED.value
                             licenses.append(detected)
                 except Exception as e:
                     logger.debug(f"Failed to read license file {license_file_path}: {e}")
+            else:
+                logger.debug(f"License file {license_file_path} referenced in pyproject.toml does not exist")
 
         # Patterns for other pyproject.toml license formats
         patterns = [


### PR DESCRIPTION
## Summary
- Fixed pyproject.toml PEP 639 `license = {file = "LICENSE"}` format support  
- Bumped version to 1.4.1
- Updated CHANGELOG with all recent changes

## Changes
1. **Fixed pyproject.toml file reference bug** (closes #18):
   - Changed from non-existent `_detect_license_from_text()` to proper `_detect_from_full_text()` method
   - Now correctly reads and detects licenses from referenced files in pyproject.toml
   - Properly sets category as DECLARED for licenses from metadata file references
   - Added debug logging when referenced license file doesn't exist

2. **Version bump to 1.4.1**:
   - Updated version in `pyproject.toml`
   - Updated version in `__init__.py`

3. **Updated CHANGELOG**:
   - Added v1.4.1 entry with fixes
   - Moved notices removal to v1.4.1 (was implemented after v1.4.0 release)

## Test Results
Verified all functionality works correctly:
- ✅ Basic license detection (MIT, Apache-2.0)
- ✅ SPDX identifier detection
- ✅ Package metadata extraction (package.json, pyproject.toml)
- ✅ Copyright extraction
- ✅ All output formats (Evidence, KissBOM, CycloneDX)
- ✅ Complex license expressions
- ✅ Downloads folder scan (628 files, 31 licenses, 402 copyright holders)

## Related Issues
- Fixes remaining issues from #18 (pyproject.toml support)
- Completes work from #19 (notices format removal)