### PR TITLE
docs: Remove notices format references from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ oslili /path/to/project
 # Generate different output formats
 oslili ./my-project -f kissbom -o kissbom.json
 oslili ./my-project -f cyclonedx-json -o sbom.json
-oslili ./my-project -f notices -o NOTICE.txt
+oslili ./my-project -f cyclonedx-xml -o sbom.xml
 
 # Scan with parallel processing (4 threads)
 oslili ./my-project --threads 4
@@ -168,7 +168,7 @@ result = detector.process_local_path("/path/to/LICENSE")
 evidence = detector.generate_evidence([result])
 kissbom = detector.generate_kissbom([result])
 cyclonedx = detector.generate_cyclonedx([result], format_type="json")
-notices = detector.generate_notices([result])
+cyclonedx_xml = detector.generate_cyclonedx([result], format_type="xml")
 
 # Access results directly
 for license in result.licenses:

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="semantic-copycat-oslili",
-    version="1.2.9",
+    version="1.4.1",
     author="Oscar Valenzuela B.",
     author_email="oscar.valenzuela.b@gmail.com",
-    description="Legal attribution notice generator for software packages",
+    description="License and copyright detector for software packages",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/oscarvalenzuelab/semantic-copycat-oslili",


### PR DESCRIPTION
## Summary
Cleaning up documentation to remove references to the notices output format that was removed in v1.4.1.

## Changes
1. **README.md**:
   - Removed `notices` output format from CLI examples
   - Removed `generate_notices()` from Python API examples
   - Replaced with CycloneDX XML format examples

2. **setup.py**:
   - Updated description from "notice generator" to "License and copyright detector"
   - Updated version to 1.4.1 to match current release

## Note
The notices format was removed as part of v1.4.1 to focus the tool on its primary purpose as a scanner/verifier rather than a notice generator. This PR completes the cleanup by removing lingering references in documentation.