### PR TITLE
fix: Improve copyright detection for holders containing test-related words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2025-10-17
+
+### Fixed
+- **Copyright Detection**: Fixed overly aggressive filtering of copyright holders (issue #32)
+  - Copyright holders containing words like "Test", "Demo", etc. are now correctly detected when part of legitimate names
+  - "Test Corporation", "TestCo Inc", and similar names are now properly recognized
+  - Only standalone test/demo placeholders are filtered out (e.g., just "test" or "demo")
+  - Maintains filtering of actual placeholder text while allowing real organizations with these words
+
 ## [1.5.0] - 2025-10-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "semantic-copycat-oslili"
-version = "1.5.0"
+version = "1.5.1"
 description = "Semantic Copycat Open Source License Identification Library"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/semantic_copycat_oslili/__init__.py
+++ b/semantic_copycat_oslili/__init__.py
@@ -13,7 +13,7 @@ if os.environ.get('OSLILI_DEBUG') != '1':
     except ImportError:
         pass
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 from .core.generator import LicenseCopyrightDetector
 from .core.models import (

--- a/semantic_copycat_oslili/extractors/copyright_extractor.py
+++ b/semantic_copycat_oslili/extractors/copyright_extractor.py
@@ -438,15 +438,28 @@ class CopyrightExtractor:
         invalid_phrases = [
             'copyright', 'license', 'patent', 'you must', 'notice',
             'owner or entity', 'owner that', 'information', 'extraction',
-            'regex match', 'name format', 'years', 'statement', 
+            'regex match', 'name format', 'years', 'statement',
             'holder', 'owner', 's_from', 's =', 'info"', 's_found',
             'evidence', 'by source', 's in ', 'you comply', 'their terms',
             'in result', 'lines that vary', 'may vary', 'will vary',
             'varies', 'variable', 'placeholder', 'example', 'sample',
-            'test', 'demo', 'dummy', 'foo', 'bar', 'baz', 'lorem ipsum',
-            'detector', 'generator', 'scanner', 'analyzer', 'processor'
+            'lorem ipsum', 'detector', 'generator', 'scanner', 'analyzer', 'processor'
         ]
-        
+
+        # Check for exact matches of test placeholders (not as part of larger names)
+        # Only filter if it's EXACTLY these words (case-insensitive)
+        test_placeholders = ['test', 'demo', 'dummy', 'foo', 'bar', 'baz']
+        if holder_lower.strip() in test_placeholders:
+            return ""
+
+        # For test-related words, only filter if they're standalone words
+        # Allow names like "Test Corporation" or "TestCo Inc"
+        test_word_patterns = [r'\btest\b', r'\bdemo\b', r'\bdummy\b', r'\bfoo\b', r'\bbar\b', r'\bbaz\b']
+        for pattern in test_word_patterns:
+            # Check if it's ONLY the test word (not part of a larger name)
+            if re.fullmatch(pattern, holder_lower):
+                return ""
+
         for phrase in invalid_phrases:
             if phrase in holder_lower:
                 return ""


### PR DESCRIPTION
## Summary
- Fixes #32 - Copyright detection now works correctly for legitimate company names containing test-related words
- Refactored filtering logic to be more precise about what constitutes a placeholder vs real name
- Version bumped to 1.5.1

## Problem
The copyright extractor was overly aggressive in filtering out copyright holders. Any name containing words like "test", "demo", "foo", etc. would be rejected, even legitimate company names like "Test Corporation" or "TestCo Inc."

## Solution  
Modified the `_clean_holder()` method in `copyright_extractor.py` to:
1. Remove test-related words from the general substring filter list
2. Add specific logic to only filter exact matches of placeholder words
3. Allow names like "Test Corporation" while still filtering standalone "test"

## Testing
Created comprehensive test cases verifying:
- ✅ "Test Corporation" is detected
- ✅ "TestCo Inc." is detected  
- ✅ "Test Author" is detected
- ✅ Standalone "test" is still filtered
- ✅ Standalone "demo", "foo", etc. are still filtered
- ✅ Real-world examples like "TJ Holowaychuk" and "Meta Platforms" work correctly

## Test Results
```python
✓ Correctly detected: Copyright (c) 2024 John Doe -> John Doe
✓ Correctly detected: Copyright © 2024 Jane Smith -> Jane Smith
✓ Correctly detected: Copyright 2024 Bob Johnson -> Bob Johnson
✓ Correctly detected: Copyright (c) 2024 Test Corporation -> Test Corporation
✓ Correctly detected: Copyright (c) 2024 TestCo Inc. -> TestCo Inc
✓ Correctly filtered: Copyright (c) 2024 test
✓ Correctly filtered: Copyright (c) 2024 demo
✓ Correctly filtered: Copyright (c) 2024 foo

✅ All tests passed!
```

## Changes
- `semantic_copycat_oslili/extractors/copyright_extractor.py`: Improved holder filtering logic
- `pyproject.toml`: Version bump to 1.5.1
- `semantic_copycat_oslili/__init__.py`: Version bump to 1.5.1
- `CHANGELOG.md`: Document fix for v1.5.1