### PR TITLE
fix: Correct version from 1.6.9 to 1.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.6.9] - 2025-11-14
+## [1.5.9] - 2025-11-14
 
 ### Added
 - **Performance Optimization Flags**: New configurable flags for faster scanning (Issue #49)

--- a/osslili/__init__.py
+++ b/osslili/__init__.py
@@ -13,7 +13,7 @@ if os.environ.get('OSLILI_DEBUG') != '1':
     except ImportError:
         pass
 
-__version__ = "1.6.9"
+__version__ = "1.5.9"
 
 from .core.generator import LicenseCopyrightDetector
 from .core.models import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "osslili"
-version = "1.6.9"
+version = "1.5.9"
 description = "Open Source License Identification Library"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary

This PR corrects an error in the version numbering. The version was incorrectly bumped to **1.6.9** instead of the intended **1.5.9**.

## Problem

After merging PR #50, the version was set to 1.6.9, which skips several versions:
- Previous version: **1.5.7**
- Incorrect bump: **1.6.9** (skipped 1.5.8, 1.5.9, 1.6.0-1.6.8)
- Correct bump: **1.5.9**

## Changes

Updated version from **1.6.9** → **1.5.9** in:

1. **pyproject.toml** - Package version
2. **osslili/__init__.py** - Module version constant
3. **CHANGELOG.md** - Version heading

## Impact

- Restores proper semantic versioning sequence
- No functional changes to code
- CHANGELOG entry remains the same, only header version corrected

## Verification

```bash
grep "version" pyproject.toml
# version = "1.5.9"

grep "__version__" osslili/__init__.py  
# __version__ = "1.5.9"

grep "## \[1\." CHANGELOG.md | head -1
# ## [1.5.9] - 2025-11-14
```