### PR TITLE
Release v1.6.3

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,0 +1,8 @@
+{
+  "message": "Thank you for your contribution! Before we can review and merge your pull request, we need you to sign our Contributor License Agreement (CLA).\n\n**To sign the CLA:**\n\n1. Review the agreement below\n2. Reply to this PR with the following statement:\n\n> I have read the Contributor License Agreement and I hereby accept the terms.\n\n**Contributor License Agreement (Summary)**\n\nBy signing this CLA, you certify that:\n\n- You created the contribution or have the right to submit it under the Apache 2.0 license\n- You grant SEMCL.ONE and recipients of this software a perpetual, worldwide, non-exclusive, royalty-free license to use, reproduce, modify, and distribute your contribution\n- You understand that your contribution is public and may be redistributed under the Apache 2.0 license\n- You have the legal right to make this grant (if employed, your employer has waived rights or you are contributing outside the scope of employment)\n- You agree to notify us if you become aware of any facts that would make these representations inaccurate\n\nThis agreement is based on the Apache Software Foundation CLA. Your contribution will remain publicly available under the Apache 2.0 license.\n\nOnce you post your acceptance, we'll review your contribution. Thank you!\n\n---\n\nQuestions? Contact legal@semcl.one",
+  "label": "cla-signed",
+  "recheckComment": "recheck",
+  "contributors": [
+    "oscarvalenzuelab"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to osslili will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2026-01-31
+
+### Fixed
+- **SPDX Compliance**: Fixed invalid SPDX license suffix generation (Issue #64)
+  - Prevented `-only` and `-or-later` suffixes from being added to non-GNU licenses
+  - Invalid IDs like `MIT-only`, `Apache-2.0-only`, `BSD-3-Clause-only` are no longer generated
+  - Suffixes now only applied to GNU family licenses: GPL, LGPL, AGPL, GFDL (per SPDX spec)
+  - Improves compatibility with SBOM validators and compliance tools
+- **License Detection**: Reduced false negatives for BlueOak licenses (Issue #63)
+  - Added `blueoak-` to valid license ID patterns
+  - `BlueOak-1.0.0` and other BlueOak licenses now correctly detected
+
+### Technical Details
+- Added whitelist validation in `handle_version_suffix()` function
+- Only GNU licenses (GPL-*/LGPL-*/AGPL-*/GFDL-*) receive version suffixes
+- All other licenses return base SPDX ID without modification
+- Maintains backward compatibility for existing GNU license detection
+
 ## [1.6.1] - 2025-11-22
 
 ### Fixed

--- a/osslili/__init__.py
+++ b/osslili/__init__.py
@@ -13,7 +13,7 @@ if os.environ.get('OSLILI_DEBUG') != '1':
     except ImportError:
         pass
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 from .core.generator import LicenseCopyrightDetector
 from .core.models import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "osslili"
-version = "1.6.2"
+version = "1.6.3"
 description = "Open Source License Identification Library"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Release v1.6.3

This PR bumps the version to 1.6.3 and includes the following fixes:

### Fixed Issues

- **#64**: Invalid SPDX license suffix generation
- **#63**: BlueOak license false negatives

### Changes in This PR

- ✅ Updated version: `1.6.2` → `1.6.3`
  - `osslili/__init__.py`
  - `pyproject.toml`
- ✅ Added CHANGELOG entry for v1.6.3

### Key Improvements

#### SPDX Compliance Fix (#64)
- Prevents generation of invalid SPDX IDs like `MIT-only`, `Apache-2.0-only`, `BSD-3-Clause-only`
- Suffixes (`-only`, `-or-later`) now only applied to GNU family licenses (GPL, LGPL, AGPL, GFDL)
- Improves compatibility with SBOM validators and compliance tools
- Fully tested and verified

#### BlueOak License Detection (#63)
- Added `blueoak-` to valid license ID patterns
- `BlueOak-1.0.0` and other BlueOak licenses now correctly detected
- Reduces false negatives in license detection

### Release Notes

The CHANGELOG has been updated with full details of both fixes, including:
- Technical implementation details
- Impact on SPDX compliance
- Backward compatibility notes

### Testing

Both fixes have been thoroughly tested:
- ✅ SPDX suffix fix tested with MIT, Apache-2.0, and GPL-2.0 licenses
- ✅ BlueOak detection verified against SPDX license data
- ✅ No regressions in existing license detection

Ready for approval and release! 🚀