### PR TITLE
fix(detector): emit modern SPDX ids for deprecated GNU-family licenses

### DIFF
--- a/osslili/detectors/license_detector.py
+++ b/osslili/detectors/license_detector.py
@@ -22,6 +22,12 @@ from ..utils.regex_matcher import RegexPatternMatcher
 
 logger = logging.getLogger(__name__)
 
+# SPDX deprecated the bare GNU-family short identifiers (e.g. "GPL-2.0") in
+# favour of an explicit -only / -or-later disjunction, because the bare id is
+# ambiguous about whether later license versions are permitted. This matches a
+# bare GNU-family id so it can be mapped to its modern replacement.
+_DEPRECATED_GNU_RE = re.compile(r'^(?:A?GPL|LGPL|GFDL)-\d+(?:\.\d+)?$')
+
 
 class LicenseDetector:
     """Detect licenses in source code using multiple detection methods."""
@@ -283,6 +289,9 @@ class LicenseDetector:
                     try:
                         file_licenses = future.result(timeout=30)  # 30 second timeout per file
                         for license in file_licenses:
+                            # Emit modern SPDX ids; the bare GNU-family forms
+                            # osslili's detectors produce are deprecated.
+                            license.spdx_id = self._to_modern_spdx_id(license.spdx_id)
                             # Never emit identifiers outside the SPDX list.
                             if not self._is_emittable_license_id(license.spdx_id):
                                 logger.debug(
@@ -304,6 +313,9 @@ class LicenseDetector:
                 try:
                     file_licenses = self._detect_licenses_in_file(file_path, single_file_mode)
                     for license in file_licenses:
+                        # Emit modern SPDX ids; the bare GNU-family forms
+                        # osslili's detectors produce are deprecated.
+                        license.spdx_id = self._to_modern_spdx_id(license.spdx_id)
                         # Never emit identifiers outside the SPDX list.
                         if not self._is_emittable_license_id(license.spdx_id):
                             logger.debug(
@@ -1723,6 +1735,35 @@ class LicenseDetector:
         if hasattr(self.spdx_data, 'licenses') and self.spdx_data.licenses:
             return license_id in self.spdx_data.licenses
         return False
+
+    def _to_modern_spdx_id(self, license_id: str) -> str:
+        """Map a deprecated bare GNU-family id to its modern SPDX replacement.
+
+        ``GPL-2.0`` -> ``GPL-2.0-only`` and the deprecated "or later" form
+        ``GPL-2.0+`` -> ``GPL-2.0-or-later``, matching SPDX's documented
+        replacements. Ids that are already modern, are not GNU-family, or whose
+        computed replacement is not itself a valid SPDX id are returned
+        unchanged, so an unexpected input can never produce a bogus id.
+        """
+        if not license_id or not isinstance(license_id, str):
+            return license_id
+        lid = license_id.strip()
+
+        # Deprecated "or later" form: GPL-2.0+ -> GPL-2.0-or-later.
+        if lid.endswith('+'):
+            base = lid[:-1]
+            if _DEPRECATED_GNU_RE.match(base):
+                candidate = base + '-or-later'
+                if self._is_valid_spdx_id(candidate):
+                    return candidate
+            return lid
+
+        # Bare deprecated form: GPL-2.0 -> GPL-2.0-only.
+        if _DEPRECATED_GNU_RE.match(lid):
+            candidate = lid + '-only'
+            if self._is_valid_spdx_id(candidate):
+                return candidate
+        return lid
 
     def _is_emittable_license_id(self, license_id: str) -> bool:
         """

--- a/tests/test_license_detection_accuracy.py
+++ b/tests/test_license_detection_accuracy.py
@@ -176,3 +176,47 @@ class TestEmittableLicenseIdGuard:
     ])
     def test_rejects_invalid_identifiers(self, detector, license_id):
         assert not detector._is_emittable_license_id(license_id)
+
+
+class TestDeprecatedGnuIdNormalization:
+    """Deprecated bare GNU-family ids must be emitted in modern SPDX form.
+
+    SPDX deprecated the bare ids (e.g. ``GPL-2.0``) in favour of the explicit
+    ``-only`` / ``-or-later`` disjunction. The detector's tag and text paths
+    still surface the bare forms internally, so results are normalized before
+    emission.
+    """
+
+    @pytest.mark.parametrize("deprecated,expected", [
+        ("GPL-2.0", "GPL-2.0-only"),
+        ("GPL-3.0", "GPL-3.0-only"),
+        ("LGPL-2.1", "LGPL-2.1-only"),
+        ("LGPL-3.0", "LGPL-3.0-only"),
+        ("AGPL-3.0", "AGPL-3.0-only"),
+        ("GPL-2.0+", "GPL-2.0-or-later"),
+        ("GPL-3.0+", "GPL-3.0-or-later"),
+    ])
+    def test_maps_deprecated_to_modern(self, detector, deprecated, expected):
+        assert detector._to_modern_spdx_id(deprecated) == expected
+
+    @pytest.mark.parametrize("license_id", [
+        "GPL-2.0-only",
+        "GPL-3.0-or-later",
+        "MIT",
+        "Apache-2.0",
+        "BSD-3-Clause",
+        "MIT OR GPL-2.0-only",
+    ])
+    def test_modern_and_non_gnu_ids_pass_through(self, detector, license_id):
+        assert detector._to_modern_spdx_id(license_id) == license_id
+
+    @pytest.mark.parametrize("filename,text,expected", [
+        ("LICENSE", "GNU General Public License\nVersion 2, June 1991", "GPL-2.0-only"),
+        ("LICENSE", "GNU General Public License\nVersion 3, 29 June 2007", "GPL-3.0-only"),
+        ("LICENSE", "GNU Lesser General Public License\nVersion 3, 29 June 2007", "LGPL-3.0-only"),
+        ("main.c", "/* SPDX-License-Identifier: GPL-2.0 */\nint main(){}\n", "GPL-2.0-only"),
+    ])
+    def test_detection_emits_modern_ids(self, detector, tmp_path, filename, text, expected):
+        ids = _detect_ids(detector, tmp_path, filename, text)
+        assert expected in ids, f"expected {expected} in {ids}"
+        assert "GPL-2.0" not in ids and "GPL-3.0" not in ids and "LGPL-3.0" not in ids


### PR DESCRIPTION
Closes #82.

## Problem

The detector emitted **deprecated bare SPDX ids** for the GNU family — `GPL-2.0`, `GPL-3.0`, `LGPL-3.0`, `AGPL-3.0` — from both the SPDX-tag path and the license-text path. SPDX deprecated these in favour of the explicit `-only` / `-or-later` disjunction, so downstream consumers comparing against the current SPDX list get false mismatches. (This is the upstream root cause of the workaround added in `suphm`.)

## Fix

- Add `_to_modern_spdx_id`: maps a deprecated bare GNU-family id to its modern replacement — `GPL-2.0` → `GPL-2.0-only`, and the deprecated `+` form `GPL-2.0+` → `GPL-2.0-or-later`. It only rewrites when the computed replacement is itself a valid SPDX id, so an unexpected input can never yield a bogus id; modern and non-GNU ids pass through untouched.
- Apply it at the single emission boundary (both the parallel and sequential collection loops), before the SPDX-list guard and dedup, so every one of the ~20 detection construction sites is covered.

## Tests

Added `TestDeprecatedGnuIdNormalization`: unit coverage for the mapping (incl. pass-through of modern/non-GNU ids) and end-to-end detection from GPL/LGPL headers and an `SPDX-License-Identifier: GPL-2.0` tag.

```
pytest tests/ -q   # 81 passed (64 prior + 17 new)
```

## Known follow-ups (not in scope here)

- **AGPL-3.0 from a bare header** still produces no hit — a detection gap noted in #82, separate from this normalization.
- An explicit `GPL-2.0+` **tag** currently resolves to `-only` because the `+` is stripped upstream before reaching the emission boundary; recovering `-or-later` for that case needs the `+` preserved earlier in the tag path. `_to_modern_spdx_id` already handles `+` correctly for when that lands.