### PR TITLE
chore(release): v1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to osslili will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.5] - 2026-07-24
+
+### Fixed
+- **SPDX Compliance**: Emit modern SPDX ids for deprecated GNU-family licenses (Issue #82)
+  - The tag and text detectors surfaced deprecated bare ids (`GPL-2.0`, `GPL-3.0`, `LGPL-3.0`, `AGPL-3.0`), which SPDX replaced with the explicit `-only` / `-or-later` disjunction
+  - Detected ids are now normalized to their modern replacement at the emission boundary — `GPL-2.0` → `GPL-2.0-only`, and the deprecated `+` form `GPL-2.0+` → `GPL-2.0-or-later`
+  - Normalization only applies when the computed replacement is itself a valid SPDX id, so unexpected inputs can never produce a bogus id; modern and non-GNU ids pass through unchanged
+
+### Technical Details
+- Added `_to_modern_spdx_id()` applied before the SPDX-list guard and dedup in both the parallel and sequential collection paths
+- Added `TestDeprecatedGnuIdNormalization` regression coverage (unit mapping + end-to-end detection)
+
 ## [1.6.4] - 2026-07-21
 
 ### Fixed

--- a/osslili/__init__.py
+++ b/osslili/__init__.py
@@ -13,7 +13,7 @@ if os.environ.get('OSLILI_DEBUG') != '1':
     except ImportError:
         pass
 
-__version__ = "1.6.4"
+__version__ = "1.6.5"
 
 from .core.generator import LicenseCopyrightDetector
 from .core.models import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "osslili"
-version = "1.6.4"
+version = "1.6.5"
 description = "Open Source License Identification Library"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Release 1.6.5.

Bumps version 1.6.4 → 1.6.5 (pyproject + `osslili/__init__.py`) and adds the changelog entry for the deprecated-GNU-id normalization fix (#82, merged in #83).

After merge, tag `v1.6.5` to trigger the PyPI publish workflow.