### PR TITLE
Remove redundant THIRD_PARTY_NOTICES* license filename pattern

### DIFF
--- a/osslili/core/models.py
+++ b/osslili/core/models.py
@@ -112,7 +112,7 @@ class Config:
         "LICENSE*", "LICENCE*", "COPYING*", "NOTICE*",
         "MIT-LICENSE*", "APACHE-LICENSE*", "BSD-LICENSE*",
         "UNLICENSE*", "COPYRIGHT*", "3rdpartylicenses.txt",
-        "THIRD_PARTY_NOTICES*", "*GPL*", "*COPYLEFT*", 
+        "*GPL*", "*COPYLEFT*",
         "*EULA*", "*COMMERCIAL*", "*AGREEMENT*", "*BUNDLE*",
         "*THIRD-PARTY*", "*THIRD_PARTY*", "LEGAL*"
     ])


### PR DESCRIPTION
Closes #80.

`THIRD_PARTY_NOTICES*` is fully covered by the existing `*THIRD_PARTY*` pattern — any filename beginning with `THIRD_PARTY_NOTICES` contains the substring `THIRD_PARTY`, so it is already matched.

## Verification
- Filename matching is **set membership** (a file matching *any* pattern is treated as a license file — `license_detector.py` compiles all patterns and `file_scanner.py` matches via `fnmatch`). Ordering carries **no priority**, so removing a duplicate is behavior-neutral. This also answers the ordering question raised in the issue thread.
- The removed pattern is a strict subset of `*THIRD_PARTY*`; every name it matched (`THIRD_PARTY_NOTICES`, `THIRD_PARTY_NOTICES.txt`, `.md`, …) still matches. Confirmed with `fnmatch`.
- No other references to `THIRD_PARTY_NOTICES` in the codebase or tests.
- Full suite green: 81 passed.