### PR TITLE
Categorize bundled third-party notices separately (#78)

### DIFF
--- a/osslili/core/models.py
+++ b/osslili/core/models.py
@@ -23,6 +23,7 @@ class LicenseCategory(Enum):
     DECLARED = "declared"  # Explicitly declared in LICENSE files, package.json, etc.
     DETECTED = "detected"  # Inferred from source code content
     REFERENCED = "referenced"  # Mentioned but not primary
+    THIRD_PARTY = "third-party"  # Bundled third-party notice/license files (deps, not the project itself)
 
 
 @dataclass
@@ -80,11 +81,32 @@ class DetectionResult:
     package_name: Optional[str] = None
     package_version: Optional[str] = None
     
+    def get_own_licenses(self) -> List[DetectedLicense]:
+        """Licenses representing the project itself.
+
+        Excludes bundled third-party notice files, which carry dependency
+        licenses rather than the project's own license (issue #78).
+        """
+        return [l for l in self.licenses
+                if l.category != LicenseCategory.THIRD_PARTY.value]
+
+    def get_third_party_licenses(self) -> List[DetectedLicense]:
+        """Licenses detected in bundled third-party notice files (issue #78)."""
+        return [l for l in self.licenses
+                if l.category == LicenseCategory.THIRD_PARTY.value]
+
     def get_primary_license(self) -> Optional[DetectedLicense]:
-        """Get the license with highest confidence."""
-        if not self.licenses:
+        """Get the highest-confidence license representing the project itself.
+
+        Bundled third-party dependency licenses are never selected as the
+        project's primary license (issue #78). If only third-party notice
+        licenses were detected, there is no project-owned primary license and
+        this returns None (they remain available via get_third_party_licenses).
+        """
+        own_licenses = self.get_own_licenses()
+        if not own_licenses:
             return None
-        return max(self.licenses, key=lambda x: x.confidence)
+        return max(own_licenses, key=lambda x: x.confidence)
     
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/osslili/detectors/license_detector.py
+++ b/osslili/detectors/license_detector.py
@@ -70,7 +70,12 @@ class LicenseDetector:
         """
         file_name = file_path.name.lower()
         file_str = str(file_path).lower()
-        
+
+        # Bundled third-party notices are dependency licenses, not the project's
+        # own license. Tag them separately so they can be filtered out (issue #78).
+        if self._is_third_party_notice_file(file_path):
+            return LicenseCategory.THIRD_PARTY.value, "third_party_notice"
+
         # Primary declared licenses - found in LICENSE files or package metadata
         if self._is_license_file(file_path):
             return LicenseCategory.DECLARED.value, "license_file"
@@ -331,9 +336,17 @@ class LicenseDetector:
                 except Exception as e:
                     logger.warning(f"Error processing {file_path}: {e}")
         
+        # Re-tag bundled third-party notices (issue #78). Several construction
+        # paths hard-code the DECLARED category; normalize here at the single
+        # exit point so any license sourced from a third-party notice file is
+        # reported under the THIRD_PARTY category regardless of how it was built.
+        for license in licenses:
+            if license.source_file and self._is_third_party_notice_file(Path(license.source_file)):
+                license.category = LicenseCategory.THIRD_PARTY.value
+
         # Sort by confidence
         licenses.sort(key=lambda x: x.confidence, reverse=True)
-        
+
         return licenses
     
     def _detect_licenses_in_file_safe(self, file_path: Path, single_file_mode: bool = False) -> List[DetectedLicense]:
@@ -745,6 +758,28 @@ class LicenseDetector:
 
         return filtered_licenses
     
+    # A bundled *third-party* notice/license file (licenses of dependencies
+    # shipped alongside the project) is identified by a "third party" marker
+    # combined with a notice/license token. Requiring both avoids misclassifying
+    # ordinary source files such as ``third_party_helpers.py`` as license files.
+    # These files are still detected and reported, but tagged with the
+    # THIRD_PARTY category so consumers determining the project's own license in
+    # isolation (e.g. ORT) can filter them out. See issue #78.
+    _THIRD_PARTY_MARKERS = (
+        'third-party', 'third_party', 'thirdparty',
+        '3rdparty', '3rd-party', '3rd_party',
+    )
+    _THIRD_PARTY_NOTICE_TOKENS = (
+        'notice', 'license', 'licence', 'legal', 'attribution',
+    )
+
+    def _is_third_party_notice_file(self, file_path: Path) -> bool:
+        """Check if a file is a bundled third-party notice/license file."""
+        name_lower = file_path.name.lower()
+        has_marker = any(m in name_lower for m in self._THIRD_PARTY_MARKERS)
+        has_token = any(t in name_lower for t in self._THIRD_PARTY_NOTICE_TOKENS)
+        return has_marker and has_token
+
     def _is_license_file(self, file_path: Path) -> bool:
         """Check if file is likely a license file."""
         name_lower = file_path.name.lower()
@@ -2093,9 +2128,12 @@ class LicenseDetector:
         Returns:
             Adjusted confidence score
         """
-        if category == "declared":
+        # Bundled third-party notice files are still license files, just
+        # categorized separately (issue #78); they keep the same high
+        # confidence treatment as declared license files.
+        if category in ("declared", "third-party"):
             # License files and documentation should have high confidence
-            if match_type == "license_file":
+            if match_type in ("license_file", "third_party_notice"):
                 return 1.0  # Full confidence for exact license file matches
             elif match_type == "documentation":
                 return min(0.95, raw_score + 0.2)  # High confidence for docs

--- a/osslili/formatters/cyclonedx_formatter.py
+++ b/osslili/formatters/cyclonedx_formatter.py
@@ -46,19 +46,32 @@ class CycloneDXFormatter:
                 "version": result.package_version or "unknown"
             }
             
-            # Add licenses
+            # Add the project's own licenses. Bundled third-party notice
+            # licenses are not listed as the component's license; they are
+            # emitted as properties so they remain visible but filterable
+            # (issue #78).
             licenses = []
-            for license_info in result.licenses:
+            for license_info in result.get_own_licenses():
                 if license_info.spdx_id and license_info.spdx_id != "NO-ASSERTION":
                     licenses.append({
                         "license": {
                             "id": license_info.spdx_id
                         }
                     })
-            
+
             if licenses:
                 component["licenses"] = licenses
-            
+
+            third_party_ids = sorted(set(
+                l.spdx_id for l in result.get_third_party_licenses()
+                if l.spdx_id and l.spdx_id != "NO-ASSERTION"
+            ))
+            if third_party_ids:
+                component["properties"] = [
+                    {"name": "osslili:third-party-license", "value": spdx_id}
+                    for spdx_id in third_party_ids
+                ]
+
             # Add copyright
             if result.copyrights:
                 copyright_text = "\n".join(c.statement for c in result.copyrights)
@@ -135,19 +148,35 @@ class CycloneDXFormatter:
             version = ET.SubElement(component, "version")
             version.text = result.package_version or "unknown"
             
-            # Add licenses
-            if result.licenses:
+            # Add the project's own licenses (issue #78: bundled third-party
+            # notice licenses are emitted as properties, not component licenses).
+            own_licenses = result.get_own_licenses()
+            if own_licenses:
                 licenses_elem = ET.SubElement(component, "licenses")
-                for license_info in result.licenses:
+                for license_info in own_licenses:
                     if license_info.spdx_id and license_info.spdx_id != "NO-ASSERTION":
                         license_elem = ET.SubElement(licenses_elem, "license")
                         id_elem = ET.SubElement(license_elem, "id")
                         id_elem.text = license_info.spdx_id
-            
-            # Add copyright
+
+            # Add copyright (must precede <properties> in the CycloneDX 1.4
+            # XML component sequence).
             if result.copyrights:
                 copyright_elem = ET.SubElement(component, "copyright")
                 copyright_elem.text = "\n".join(c.statement for c in result.copyrights)
+
+            third_party_ids = sorted(set(
+                l.spdx_id for l in result.get_third_party_licenses()
+                if l.spdx_id and l.spdx_id != "NO-ASSERTION"
+            ))
+            if third_party_ids:
+                properties_elem = ET.SubElement(component, "properties")
+                for spdx_id in third_party_ids:
+                    prop_elem = ET.SubElement(
+                        properties_elem, "property",
+                        {"name": "osslili:third-party-license"}
+                    )
+                    prop_elem.text = spdx_id
         
         # Convert to string
         return ET.tostring(root, encoding="unicode", method="xml")

--- a/osslili/formatters/evidence_formatter.py
+++ b/osslili/formatters/evidence_formatter.py
@@ -34,6 +34,7 @@ class EvidenceFormatter:
                 "declared_licenses": {},
                 "detected_licenses": {},
                 "referenced_licenses": {},
+                "third_party_licenses": {},
                 "all_licenses": {},
                 "copyright_holders": [],
                 "copyrights_found": 0
@@ -124,6 +125,10 @@ class EvidenceFormatter:
                         if spdx_id not in evidence["summary"]["referenced_licenses"]:
                             evidence["summary"]["referenced_licenses"][spdx_id] = 0
                         evidence["summary"]["referenced_licenses"][spdx_id] += 1
+                    elif category == "third-party":
+                        if spdx_id not in evidence["summary"]["third_party_licenses"]:
+                            evidence["summary"]["third_party_licenses"][spdx_id] = 0
+                        evidence["summary"]["third_party_licenses"][spdx_id] += 1
 
                     # Add to overall count
                     if spdx_id not in evidence["summary"]["all_licenses"]:
@@ -230,6 +235,10 @@ class EvidenceFormatter:
                             if spdx_id not in evidence["summary"]["referenced_licenses"]:
                                 evidence["summary"]["referenced_licenses"][spdx_id] = 0
                             evidence["summary"]["referenced_licenses"][spdx_id] += 1
+                        elif category == "third-party":
+                            if spdx_id not in evidence["summary"]["third_party_licenses"]:
+                                evidence["summary"]["third_party_licenses"][spdx_id] = 0
+                            evidence["summary"]["third_party_licenses"][spdx_id] += 1
 
                         # Add to overall count
                         if spdx_id not in evidence["summary"]["all_licenses"]:
@@ -293,6 +302,7 @@ class EvidenceFormatter:
                     "total_files_scanned": evidence["summary"]["total_files_scanned"],
                     "files_with_licenses": len(set(e["file"] for r in evidence["scan_results"] for e in r["license_evidence"])),
                     "license_breakdown": evidence["summary"]["all_licenses"],
+                    "third_party_licenses": evidence["summary"]["third_party_licenses"],
                     "total_license_detections": sum(len(r["license_evidence"]) for r in evidence["scan_results"]),
                     "copyrights_found": evidence["summary"]["copyrights_found"],
                     "unique_copyright_holders": len(evidence["summary"]["copyright_holders"])
@@ -313,6 +323,7 @@ class EvidenceFormatter:
                     "total_files_scanned": evidence["summary"]["total_files_scanned"],
                     "files_with_licenses": len(set(e["file"] for r in evidence["scan_results"] for e in r["license_evidence"])),
                     "license_breakdown": evidence["summary"]["all_licenses"],
+                    "third_party_licenses": evidence["summary"]["third_party_licenses"],
                     "total_license_detections": sum(len(r["license_evidence"]) for r in evidence["scan_results"]),
                     "detection_methods": method_counts,
                     "copyrights_found": evidence["summary"]["copyrights_found"],

--- a/osslili/formatters/kissbom_formatter.py
+++ b/osslili/formatters/kissbom_formatter.py
@@ -49,11 +49,20 @@ class KissBOMFormatter:
                 package["name"] = result.package_name
             if result.package_version:
                 package["version"] = result.package_version
-                
-            # Add all detected licenses if multiple
-            if len(result.licenses) > 1:
-                package["all_licenses"] = list(set(l.spdx_id for l in result.licenses))
-            
+
+            # Add all of the project's own detected licenses if multiple.
+            # Bundled third-party notice licenses are reported separately so
+            # they are not conflated with the project's own license (issue #78).
+            own_licenses = result.get_own_licenses()
+            if len(own_licenses) > 1:
+                package["all_licenses"] = sorted(set(l.spdx_id for l in own_licenses))
+
+            third_party_ids = sorted(set(
+                l.spdx_id for l in result.get_third_party_licenses()
+            ))
+            if third_party_ids:
+                package["third_party_licenses"] = third_party_ids
+
             packages.append(package)
         
         kissbom = {

--- a/tests/test_third_party_category.py
+++ b/tests/test_third_party_category.py
@@ -1,0 +1,218 @@
+"""Tests for third-party notice categorization (issue #78).
+
+Bundled third-party notice/license files are dependency licenses, not the
+project's own license. They must still be detected and reported, but tagged
+with the THIRD_PARTY category so consumers determining the project's own
+license in isolation can filter them out.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import json
+
+from osslili.core.models import (
+    Config,
+    DetectedLicense,
+    DetectionResult,
+    LicenseCategory,
+)
+from osslili.detectors.license_detector import LicenseDetector
+from osslili.formatters.cyclonedx_formatter import CycloneDXFormatter
+from osslili.formatters.kissbom_formatter import KissBOMFormatter
+
+
+@pytest.fixture
+def detector():
+    return LicenseDetector(Config())
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "THIRD_PARTY_NOTICES.txt",
+        "THIRD_PARTY_NOTICES",
+        "third-party-licenses.md",
+        "ThirdPartyNotices.txt",
+        "3rdpartylicenses.txt",
+        "3rd-party-notices.txt",
+    ],
+)
+def test_third_party_notice_files_are_recognized(detector, filename):
+    assert detector._is_third_party_notice_file(Path(filename)) is True
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "LICENSE",
+        "LICENSE.txt",
+        "COPYING",
+        "NOTICE",
+        "README.md",
+        "COPYRIGHT",
+        # marker present but no notice/license token -> ordinary source file
+        "third_party_helpers.py",
+        "thirdparty_adapter.js",
+        "my-third-party-api.md",
+    ],
+)
+def test_project_license_files_are_not_third_party(detector, filename):
+    assert detector._is_third_party_notice_file(Path(filename)) is False
+
+
+def _lic(spdx_id, category, confidence=0.9):
+    return DetectedLicense(
+        spdx_id=spdx_id,
+        name=spdx_id,
+        confidence=confidence,
+        detection_method="regex",
+        source_file="THIRD_PARTY_NOTICES.txt",
+        category=category,
+    )
+
+
+def test_get_own_and_third_party_licenses_split():
+    result = DetectionResult(
+        path="/proj",
+        licenses=[
+            _lic("MIT", LicenseCategory.DECLARED.value),
+            _lic("Apache-2.0", LicenseCategory.THIRD_PARTY.value),
+            _lic("BSD-3-Clause", LicenseCategory.THIRD_PARTY.value),
+        ],
+    )
+    assert [l.spdx_id for l in result.get_own_licenses()] == ["MIT"]
+    assert sorted(l.spdx_id for l in result.get_third_party_licenses()) == [
+        "Apache-2.0",
+        "BSD-3-Clause",
+    ]
+
+
+def test_primary_license_ignores_third_party_even_at_higher_confidence():
+    result = DetectionResult(
+        path="/proj",
+        licenses=[
+            _lic("MIT", LicenseCategory.DECLARED.value, confidence=0.5),
+            _lic("GPL-3.0-only", LicenseCategory.THIRD_PARTY.value, confidence=0.99),
+        ],
+    )
+    assert result.get_primary_license().spdx_id == "MIT"
+
+
+def test_primary_license_is_none_when_only_third_party():
+    """Third-party notices are never promoted to the project's primary license."""
+    result = DetectionResult(
+        path="/proj",
+        licenses=[_lic("GPL-3.0-only", LicenseCategory.THIRD_PARTY.value)],
+    )
+    assert result.get_primary_license() is None
+
+
+def test_kissbom_third_party_only_does_not_contaminate_license():
+    result = DetectionResult(
+        path="/proj",
+        licenses=[_lic("GPL-3.0-only", LicenseCategory.THIRD_PARTY.value)],
+    )
+    pkg = json.loads(KissBOMFormatter().format([result]))["packages"][0]
+    assert pkg["license"] == "NO-ASSERTION"
+    assert pkg["third_party_licenses"] == ["GPL-3.0-only"]
+
+
+def test_kissbom_separates_third_party():
+    result = DetectionResult(
+        path="/proj",
+        licenses=[
+            _lic("MIT", LicenseCategory.DECLARED.value, confidence=0.9),
+            _lic("Apache-2.0", LicenseCategory.DETECTED.value, confidence=0.8),
+            _lic("GPL-3.0-only", LicenseCategory.THIRD_PARTY.value, confidence=0.99),
+        ],
+    )
+    out = json.loads(KissBOMFormatter().format([result]))
+    pkg = out["packages"][0]
+    assert pkg["license"] == "MIT"  # never the third-party GPL
+    assert "GPL-3.0-only" not in pkg.get("all_licenses", [])
+    assert pkg["third_party_licenses"] == ["GPL-3.0-only"]
+
+
+def test_cyclonedx_emits_third_party_as_properties_not_licenses():
+    result = DetectionResult(
+        path="/proj",
+        licenses=[
+            _lic("MIT", LicenseCategory.DECLARED.value),
+            _lic("GPL-3.0-only", LicenseCategory.THIRD_PARTY.value),
+        ],
+    )
+    out = json.loads(CycloneDXFormatter().format([result], "json"))
+    comp = out["components"][0]
+    license_ids = {entry["license"]["id"] for entry in comp["licenses"]}
+    assert license_ids == {"MIT"}
+    prop_values = {p["value"] for p in comp.get("properties", [])}
+    assert prop_values == {"GPL-3.0-only"}
+
+
+def test_cyclonedx_xml_is_wellformed_and_orders_copyright_before_properties():
+    import xml.etree.ElementTree as ET
+
+    result = DetectionResult(
+        path="/proj",
+        licenses=[
+            _lic("MIT", LicenseCategory.DECLARED.value),
+            _lic("GPL-3.0-only", LicenseCategory.THIRD_PARTY.value),
+        ],
+    )
+    from osslili.core.models import CopyrightInfo
+
+    result.copyrights = [CopyrightInfo(holder="ACME", statement="Copyright ACME")]
+    xml = CycloneDXFormatter().format([result], "xml")
+    root = ET.fromstring(xml)  # raises if malformed
+
+    ns = {"c": "http://cyclonedx.org/schema/bom/1.4"}
+    component = root.find(".//c:component", ns)
+    child_tags = [child.tag.split("}")[-1] for child in component]
+    assert "copyright" in child_tags and "properties" in child_tags
+    assert child_tags.index("copyright") < child_tags.index("properties")
+
+
+def test_categorize_tags_third_party_notice(detector):
+    category, match_type = detector._categorize_license(
+        Path("THIRD_PARTY_NOTICES.txt"), "regex", None
+    )
+    assert category == LicenseCategory.THIRD_PARTY.value
+    assert match_type == "third_party_notice"
+
+
+def test_categorize_keeps_project_license_declared(detector):
+    category, _ = detector._categorize_license(Path("LICENSE"), "regex", None)
+    assert category == LicenseCategory.DECLARED.value
+
+
+def test_third_party_licenses_still_detected(detector, tmp_path):
+    """A third-party notices file must still surface its licenses, just tagged."""
+    third_party = tmp_path / "THIRD_PARTY_NOTICES.txt"
+    third_party.write_text(
+        "This product bundles the following components:\n\n"
+        "SPDX-License-Identifier: MIT\n"
+        "SPDX-License-Identifier: Apache-2.0\n"
+    )
+
+    results = detector.detect_licenses(third_party)
+
+    assert results, "third-party notices should still be detected"
+    spdx_ids = {r.spdx_id for r in results}
+    assert spdx_ids & {"MIT", "Apache-2.0"}
+    # Every finding sourced from the notices file is tagged THIRD_PARTY.
+    assert all(
+        r.category == LicenseCategory.THIRD_PARTY.value for r in results
+    ), [r.category for r in results]
+
+
+def test_project_license_detected_as_declared(detector, tmp_path):
+    """A normal project LICENSE must not be tagged third-party."""
+    lic = tmp_path / "LICENSE"
+    lic.write_text("SPDX-License-Identifier: MIT\n")
+
+    results = detector.detect_licenses(lic)
+
+    assert results
+    assert all(r.category != LicenseCategory.THIRD_PARTY.value for r in results)


### PR DESCRIPTION
Closes #78.

## Problem
Bundled third-party notice/license files (`THIRD_PARTY_NOTICES.txt`, `3rdpartylicenses.txt`, …) hold the licenses of dependencies shipped alongside a project, not the project's own license. As raised in #78, tools determining a project's license in isolation (e.g. ORT) need to filter these out. But simply removing detection would regress SEMCL.ONE pipelines that scan shipped/vendored artifacts, where surfacing bundled third-party licenses is the whole point.

## Approach
Keep detecting them, but tag them with a new `THIRD_PARTY` license **category** so both consumers are served: filterable for project-license determination, still present for artifact scanning.

## Changes
- **Model:** new `LicenseCategory.THIRD_PARTY`; `DetectionResult.get_own_licenses()` / `get_third_party_licenses()` helpers. `get_primary_license()` never returns a third-party license and returns `None` when only third-party notices were detected (they remain available via the helper).
- **Detection:** `_is_third_party_notice_file()` requires a third-party marker **and** a notice/license token, so ordinary source files like `third_party_helpers.py` are not misclassified. Categorized before the declared branch, and normalized at the single `detect_licenses()` exit point so the various hard-coded `DECLARED` construction sites are corrected too.
- **KissBOM:** `license` / `all_licenses` reflect the project's own licenses; third party reported under a separate `third_party_licenses` field.
- **CycloneDX:** component `licenses` use own licenses; third party emitted as `properties` (`osslili:third-party-license`). XML orders `<copyright>` before `<properties>` per the 1.4 schema sequence.
- **Evidence:** added a `third_party_licenses` summary bucket, preserved across minimal/summary/detailed/full detail levels.
- Third-party notice files keep the same high-confidence treatment as declared license files (no confidence regression).

## Out of scope (deliberate)
Path-based detection — a bare `LICENSE` inside a `third_party/` directory — is **not** handled here. Directory-name detection needs scan-root-relative context to avoid false positives when the scan root itself contains a "third-party" marker, and fits better with the scan-mode/directory work in #79.

## Tests
New `tests/test_third_party_category.py` covers marker recognition (positive/negative), categorization, primary-license selection, KissBOM/CycloneDX output separation, third-party-only fallback, and CycloneDX XML well-formedness + element order. Full suite: **107 passed**.

## Downstream impact (verified across SEMCL.ONE consumers)
Traced every code-level consumer of osslili output:

| Consumer | Reads | Status |
|---|---|---|
| purl2notices | library, all `result.licenses`, ignores category | unaffected |
| binarysniffer | library, all `result.licenses`, category passthrough | unaffected |
| upmex | CLI `-f evidence`, all `license_evidence` entries | unaffected |
| src2purl | library, hard-codes declared/detected/referenced | tracked: SemClone/src2purl#55 |
| mcp-semclone | CLI CycloneDX `component.licenses` | tracked: SemClone/mcp-semclone#47 |

Both affected consumers have backward-compatible fixes tracked in the issues above (they no-op against current osslili and activate once this ships, so there is no release-ordering constraint).
