### PR TITLE
Add fine-grained scan targets and a lightweight scanning mode (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,14 @@ osslili ./my-project -f cyclonedx-json -o sbom.json
 
 ### Scanning Modes
 
-osslili offers three scanning modes optimized for different use cases:
+osslili offers four scanning modes optimized for different use cases. Each is a preset
+over the individual scan targets (`--license-files`, `--notice-files`,
+`--package-metadata`, `--documentation`, `--source-files`) and the detection depth
+(`--text-similarity`), so any preset can be adjusted per target:
+
+```bash
+osslili ./my-project --scan-mode default|deep|license-files|lightweight
+```
 
 ####  **Default Mode** (Recommended)
 Fast and practical - scans LICENSE files, package metadata, and documentation.
@@ -110,6 +117,29 @@ osslili ./my-project --license-files-only
 **Performance**: ~7 seconds on ffmpeg-6.0
 **Use case**: When you only need declared licenses
 
+#### **Lightweight Mode** (All files, no package metadata)
+Reads every file like deep mode, but detects only SPDX tags, license keywords and
+references instead of comparing each file against all 700+ SPDX license texts, and
+disregards package manifests entirely.
+
+```bash
+osslili ./my-project --scan-mode lightweight
+```
+
+**Use case**: Running osslili as a scanner in a pipeline whose analyzer already reads
+declared licenses from package metadata - ORT, for instance, strictly separates declared
+(metadata) from detected (source) licenses.
+
+Metadata and detection depth are independent switches, so the parts can be mixed:
+
+```bash
+# Deep scan, but disregard package metadata
+osslili ./my-project --deep --no-package-metadata
+
+# Lightweight scan, but keep the full text comparison
+osslili ./my-project --scan-mode lightweight --text-similarity
+```
+
 ---
 
 ### CLI Usage
@@ -123,6 +153,12 @@ osslili /path/to/project --deep
 
 # Strict scan - LICENSE files only
 osslili /path/to/project --license-files-only
+
+# Lightweight scan - all files, cheap detection, no package metadata
+osslili /path/to/project --scan-mode lightweight
+
+# Any mode, with package metadata disregarded
+osslili /path/to/project --deep --no-package-metadata
 
 # Generate different output formats
 osslili ./my-project -f kissbom -o kissbom.json

--- a/docs/API.md
+++ b/docs/API.md
@@ -266,6 +266,31 @@ detector = LicenseCopyrightDetector(config)
 result = detector.process_local_path("/path/to/source")
 ```
 
+### Selecting Scan Targets
+
+```python
+from osslili import LicenseCopyrightDetector, Config
+
+config = Config()
+
+# Scanning modes are presets over the individual scan targets
+config.apply_scan_mode("lightweight")  # all files, cheap detection, no metadata
+print(config.scan_targets())
+# ScanTargets(license_files=True, notice_files=True, package_metadata=False,
+#             documentation=True, source_files=True)
+
+# Any target can be overridden on top of the mode
+config.apply_scan_mode("deep")
+config.scan_package_metadata = False   # deep scan, declared metadata disregarded
+config.text_similarity_matching = False  # skip the full SPDX text comparison
+
+detector = LicenseCopyrightDetector(config)
+result = detector.process_local_path("/path/to/source")
+```
+
+Available modes are in `osslili.SCAN_MODES`: `default`, `deep`, `license-files` and
+`lightweight`. Leaving a `scan_*` target as `None` follows the selected mode.
+
 ### Processing Multiple Directories
 
 ```python

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -79,6 +79,9 @@ oslili /path/to/project -o evidence.json
 # Comprehensive deep scan (all source files)
 oslili /path/to/project --deep -o evidence.json
 
+# All files, cheap detection, package metadata disregarded
+oslili /path/to/project --scan-mode lightweight -o evidence.json
+
 # Analyze current directory
 oslili .
 
@@ -88,7 +91,13 @@ oslili /path/to/LICENSE -o license-info.json
 
 ## Scanning Modes
 
-osslili offers three scanning modes optimized for different use cases:
+osslili offers four scanning modes optimized for different use cases. Each mode is a
+preset over the individual [scan targets](#scan-targets), which can be turned on or off
+on top of the selected mode.
+
+```bash
+oslili ./my-project --scan-mode default|deep|license-files|lightweight
+```
 
 ### 🚀 Default Mode (Recommended)
 
@@ -149,6 +158,9 @@ oslili ./my-project --deep
 ```bash
 # Scans ONLY LICENSE files (no metadata, no README)
 oslili ./my-project --license-files-only
+
+# Same thing, as a mode
+oslili ./my-project --scan-mode license-files
 ```
 
 **Performance**: ~7 seconds on ffmpeg-6.0
@@ -157,6 +169,51 @@ oslili ./my-project --license-files-only
 - When you only care about declared licenses
 - Quick validation of LICENSE file presence
 - Maximum performance requirements
+
+### 🪶 Lightweight Mode (All files, no metadata)
+
+**All files, cheap detection, package metadata disregarded.** Like deep mode, it reads
+every file, but it detects only SPDX tags, license keywords and references instead of
+comparing each file against all 700+ SPDX license texts, and it ignores package
+manifests entirely.
+
+```bash
+oslili ./my-project --scan-mode lightweight
+```
+
+**Use cases:**
+- Running osslili as a scanner in a pipeline whose analyzer already reads declared
+  licenses from package metadata (for example [ORT](https://github.com/oss-review-toolkit/ort),
+  which strictly separates declared from detected licenses)
+- Scanning large trees where the full text comparison is too slow
+
+Detection depth and metadata are independent switches, so the pieces can be mixed:
+
+```bash
+# Deep mode, but disregard package metadata
+oslili ./my-project --deep --no-package-metadata
+
+# Lightweight mode, but keep the full text comparison
+oslili ./my-project --scan-mode lightweight --text-similarity
+```
+
+### Scan Targets
+
+Modes are presets over these targets. Pass a target flag to override the mode:
+
+| Flag | Files | Default |
+|------|-------|---------|
+| `--license-files` / `--no-license-files` | LICENSE, COPYING, ... (the project's own) | enabled |
+| `--notice-files` / `--no-notice-files` | bundled third-party notices (`THIRD_PARTY_NOTICES`, ...) | enabled |
+| `--package-metadata` / `--no-package-metadata` | package.json, pom.xml, requirements.txt, ... | enabled, off in lightweight mode |
+| `--documentation` / `--no-documentation` | README and other readable documentation | enabled, off in license-files mode |
+| `--source-files` / `--no-source-files` | every other readable file | deep and lightweight modes only |
+| `--text-similarity` / `--no-text-similarity` | compare contents against full SPDX license texts | enabled, off in lightweight mode |
+
+A manifest that shares a documentation extension (`requirements.txt`) counts as package
+metadata, and `--no-package-metadata` also suppresses licenses and copyright holders that
+would have been read out of a manifest - including when a single manifest file is scanned
+directly.
 
 ### Performance Comparison
 
@@ -167,6 +224,9 @@ Tested on ffmpeg-6.0 (4,139 files):
 | **Strict** (`--license-files-only`) | 8 | 7s | 48x faster |
 | **Default** *(recommended)* | 31 | 8.5s | **40x faster** |
 | **Deep** (`--deep`) | 4,800+ | 5m 37s | baseline |
+
+Lightweight mode reads the same files as deep mode; skipping the full text comparison is
+what makes it fast (~150x faster than deep mode on osslili's own package directory).
 
 ---
 
@@ -192,6 +252,18 @@ oslili [OPTIONS] PATH
   - `kissbom`: Simple JSON format with packages and licenses
   - `cyclonedx-json`: CycloneDX SBOM in JSON format
   - `cyclonedx-xml`: CycloneDX SBOM in XML format
+
+#### Scanning Options
+
+- `--scan-mode`, `--mode`: Scanning mode preset: `default`, `deep`, `license-files`, `lightweight`
+- `--deep`: Alias for `--scan-mode deep`
+- `--license-files-only`: Alias for `--scan-mode license-files`
+- `--license-files` / `--no-license-files`: Scan the project's own LICENSE files
+- `--notice-files` / `--no-notice-files`: Scan bundled third-party notice files
+- `--package-metadata` / `--no-package-metadata`: Scan package metadata (package.json, pom.xml, ...)
+- `--documentation` / `--no-documentation`: Scan README and other readable documentation
+- `--source-files` / `--no-source-files`: Scan all other readable files
+- `--text-similarity` / `--no-text-similarity`: Compare file contents against full SPDX license texts
 
 #### Configuration Options
 
@@ -364,6 +436,14 @@ max_extraction_depth: 3     # Maximum archive extraction depth
 
 # Performance settings
 thread_count: 4              # Number of parallel threads
+
+# Scan targets (omit to follow the scanning mode)
+scan_license_files: true
+scan_notice_files: true
+scan_package_metadata: false  # e.g. declared licenses come from an analyzer
+scan_documentation: true
+scan_source_files: true
+text_similarity_matching: true  # compare contents against full SPDX texts
 
 # Output settings
 verbose: false

--- a/osslili/__init__.py
+++ b/osslili/__init__.py
@@ -17,16 +17,20 @@ __version__ = "1.7.0"
 
 from .core.generator import LicenseCopyrightDetector
 from .core.models import (
+    SCAN_MODES,
     DetectionResult,
     DetectedLicense,
     CopyrightInfo,
-    Config
+    Config,
+    ScanTargets
 )
 
 __all__ = [
     "LicenseCopyrightDetector",
-    "DetectionResult", 
+    "DetectionResult",
     "DetectedLicense",
     "CopyrightInfo",
     "Config",
+    "ScanTargets",
+    "SCAN_MODES",
 ]

--- a/osslili/cli.py
+++ b/osslili/cli.py
@@ -12,7 +12,7 @@ import yaml
 from colorama import init, Fore, Style
 
 from . import __version__
-from .core.models import Config
+from .core.models import SCAN_MODES, Config
 from .core.generator import LicenseCopyrightDetector
 from .utils.logging import setup_logging
 
@@ -58,6 +58,33 @@ def load_config(config_path: Optional[str]) -> Config:
     except Exception as e:
         print_warning(f"Failed to load config from {config_path}: {e}")
         return Config()
+
+
+def resolve_scan_mode(scan_mode: Optional[str], deep: bool,
+                      license_files_only: bool) -> Optional[str]:
+    """Resolve the scanning mode from --scan-mode and its legacy flag aliases.
+
+    Returns None when no mode was requested, leaving the configured default in
+    place. Contradictory requests are a usage error rather than a silent pick.
+    """
+    aliases = []
+    if deep:
+        aliases.append(('deep', '--deep'))
+    if license_files_only:
+        aliases.append(('license-files', '--license-files-only'))
+
+    if len(aliases) > 1:
+        raise click.UsageError(
+            f"{aliases[0][1]} and {aliases[1][1]} select different scanning modes; use one"
+        )
+    if scan_mode and aliases and scan_mode != aliases[0][0]:
+        raise click.UsageError(
+            f"--scan-mode {scan_mode} conflicts with {aliases[0][1]}; use one"
+        )
+
+    if scan_mode:
+        return scan_mode
+    return aliases[0][0] if aliases else None
 
 
 def detect_input_type(input_path: str) -> str:
@@ -138,7 +165,48 @@ def detect_input_type(input_path: str) -> str:
 @click.option(
     '--license-files-only',
     is_flag=True,
-    help='Strictly scan only LICENSE files (excludes metadata and README). Use --deep for all source files.'
+    help='Strictly scan only LICENSE files (excludes metadata and README). Alias for --scan-mode license-files.'
+)
+@click.option(
+    '--scan-mode', '--mode', 'scan_mode',
+    type=click.Choice(SCAN_MODES),
+    default=None,
+    help='Scanning mode preset: default (license files, metadata, docs), deep (all files), '
+         'license-files (LICENSE files only), lightweight (all files, no package metadata, '
+         'no full text comparison)'
+)
+@click.option(
+    '--license-files/--no-license-files', 'scan_license_files',
+    default=None,
+    help='Scan the project\'s own LICENSE/COPYING files (default: enabled)'
+)
+@click.option(
+    '--notice-files/--no-notice-files', 'scan_notice_files',
+    default=None,
+    help='Scan bundled third-party notice files (default: enabled)'
+)
+@click.option(
+    '--package-metadata/--no-package-metadata', 'scan_package_metadata',
+    default=None,
+    help='Scan package metadata such as package.json or pom.xml (default: enabled). '
+         'Disable when declared licenses come from a package metadata analyzer'
+)
+@click.option(
+    '--documentation/--no-documentation', 'scan_documentation',
+    default=None,
+    help='Scan README and other readable documentation (default: enabled)'
+)
+@click.option(
+    '--source-files/--no-source-files', 'scan_source_files',
+    default=None,
+    help='Scan all other readable files for embedded licenses (default: enabled in deep '
+         'and lightweight modes only)'
+)
+@click.option(
+    '--text-similarity/--no-text-similarity', 'text_similarity',
+    default=None,
+    help='Compare file contents against full SPDX license texts (default: enabled). '
+         'Disabling leaves SPDX tags, keywords and references, which is much faster'
 )
 @click.option(
     '--skip-extensionless',
@@ -163,7 +231,7 @@ def detect_input_type(input_path: str) -> str:
 @click.option(
     '--deep',
     is_flag=True,
-    help='Enable comprehensive scan of all source files (slower, more thorough)'
+    help='Enable comprehensive scan of all source files (slower, more thorough). Alias for --scan-mode deep.'
 )
 @click.version_option(version=__version__, prog_name='osslili')
 def main(
@@ -180,6 +248,13 @@ def main(
     evidence_detail: str,
     skip_content_detection: bool,
     license_files_only: bool,
+    scan_mode: Optional[str],
+    scan_license_files: Optional[bool],
+    scan_notice_files: Optional[bool],
+    scan_package_metadata: Optional[bool],
+    scan_documentation: Optional[bool],
+    scan_source_files: Optional[bool],
+    text_similarity: Optional[bool],
     skip_extensionless: bool,
     max_file_size: Optional[int],
     skip_smart_read: bool,
@@ -194,7 +269,11 @@ def main(
     - A local file to analyze
 
     By default, scans LICENSE files, package metadata (package.json, setup.py, etc.),
-    and README files for fast results. Use --deep for comprehensive source code scanning.
+    and README files for fast results. Use --deep for comprehensive source code scanning,
+    or --scan-mode lightweight to scan all files with cheap detection and no package
+    metadata. Modes are presets over the individual scan targets (--license-files,
+    --notice-files, --package-metadata, --documentation, --source-files), each of which
+    can be turned on or off on top of the selected mode.
 
     The tool performs:
     - SPDX license identification using regex and fuzzy hashing
@@ -223,13 +302,26 @@ def main(
     if fast:
         cfg.fast_mode = True
         cfg.apply_fast_mode()
-    if deep:
-        # Deep scan mode: comprehensive scan of all source files
-        cfg.deep_scan = True
-        cfg.license_files_only = False
-    if license_files_only:
-        # Explicit license_files_only flag: strict mode (only LICENSE files, no metadata/README)
-        cfg.strict_license_files = True
+    # Scanning mode preset. --deep and --license-files-only are aliases for the
+    # corresponding modes, kept for compatibility.
+    mode = resolve_scan_mode(scan_mode, deep=deep, license_files_only=license_files_only)
+    if mode:
+        cfg.apply_scan_mode(mode)
+
+    # Individual scan targets override whatever the mode selected
+    if scan_license_files is not None:
+        cfg.scan_license_files = scan_license_files
+    if scan_notice_files is not None:
+        cfg.scan_notice_files = scan_notice_files
+    if scan_package_metadata is not None:
+        cfg.scan_package_metadata = scan_package_metadata
+    if scan_documentation is not None:
+        cfg.scan_documentation = scan_documentation
+    if scan_source_files is not None:
+        cfg.scan_source_files = scan_source_files
+    if text_similarity is not None:
+        cfg.text_similarity_matching = text_similarity
+
     if skip_content_detection:
         cfg.skip_content_detection = True
     if skip_extensionless:

--- a/osslili/core/models.py
+++ b/osslili/core/models.py
@@ -2,9 +2,13 @@
 Data models for the semantic-copycat-oslili package.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import List, Optional, Dict, Any
 from enum import Enum
+
+
+# Scanning modes are presets over the individual scan targets (issue #79).
+SCAN_MODES = ("default", "deep", "license-files", "lightweight")
 
 
 class DetectionMethod(Enum):
@@ -121,6 +125,21 @@ class DetectionResult:
         }
 
 
+@dataclass(frozen=True)
+class ScanTargets:
+    """Which categories of files a scan reads (issue #79).
+
+    Resolved from the scanning mode plus any explicit per-category override, so
+    a consumer that already has declared licenses from package metadata (ORT's
+    analyzer, for instance) can scan every file while disregarding metadata.
+    """
+    license_files: bool = True      # LICENSE, COPYING, ... (the project's own)
+    notice_files: bool = True       # bundled third-party notices (issue #78)
+    package_metadata: bool = True   # package.json, pom.xml, requirements.txt, ...
+    documentation: bool = True      # README and other readable documentation
+    source_files: bool = False      # every other readable file (content scan)
+
+
 @dataclass
 class Config:
     """Configuration for the license and copyright detector."""
@@ -164,6 +183,69 @@ class Config:
     skip_smart_read: bool = False  # Read files sequentially instead of sampling start/end
     fast_mode: bool = False  # Enable multiple optimizations for maximum speed
     deep_scan: bool = False  # Enable comprehensive scan of all source files
+
+    # Fine-grained scan targets (issue #79). None means "whatever the scanning
+    # mode selects"; setting one to True/False overrides the mode's preset.
+    scan_license_files: Optional[bool] = None
+    scan_notice_files: Optional[bool] = None
+    scan_package_metadata: Optional[bool] = None
+    scan_documentation: Optional[bool] = None
+    scan_source_files: Optional[bool] = None
+
+    # Full license text comparison (exact hash, Dice-Sørensen, TLSH). Disabling
+    # it leaves the cheap detectors (SPDX tags, keywords, references) in place,
+    # which is what a lightweight all-files scan wants.
+    text_similarity_matching: bool = True
+
+    def apply_scan_mode(self, mode: str):
+        """Apply a scanning mode preset (one of SCAN_MODES).
+
+        Presets only set what the mode itself defines, so explicit scan target
+        overrides applied afterwards still win.
+        """
+        if mode not in SCAN_MODES:
+            raise ValueError(
+                f"Unknown scan mode: {mode!r} (expected one of {', '.join(SCAN_MODES)})"
+            )
+
+        if mode == "default":
+            self.license_files_only = True
+            self.strict_license_files = False
+            self.deep_scan = False
+        elif mode == "deep":
+            self.license_files_only = False
+            self.strict_license_files = False
+            self.deep_scan = True
+        elif mode == "license-files":
+            self.license_files_only = True
+            self.strict_license_files = True
+            self.deep_scan = False
+        elif mode == "lightweight":
+            # All files, cheap detection only, package metadata disregarded:
+            # for scanners whose declared licenses come from elsewhere.
+            self.license_files_only = False
+            self.strict_license_files = False
+            self.deep_scan = True
+            self.scan_package_metadata = False
+            self.text_similarity_matching = False
+
+    def scan_targets(self) -> ScanTargets:
+        """Resolve the scan targets this configuration selects."""
+        if self.strict_license_files:
+            base = ScanTargets(package_metadata=False, documentation=False)
+        elif self.deep_scan or not self.license_files_only:
+            base = ScanTargets(source_files=True)
+        else:
+            base = ScanTargets()
+
+        overrides = {
+            'license_files': self.scan_license_files,
+            'notice_files': self.scan_notice_files,
+            'package_metadata': self.scan_package_metadata,
+            'documentation': self.scan_documentation,
+            'source_files': self.scan_source_files,
+        }
+        return replace(base, **{k: v for k, v in overrides.items() if v is not None})
 
     def apply_fast_mode(self):
         """Apply fast mode preset - enables multiple optimizations for maximum speed."""

--- a/osslili/detectors/license_detector.py
+++ b/osslili/detectors/license_detector.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from fuzzywuzzy import fuzz
 
-from ..core.models import DetectedLicense, DetectionMethod, LicenseCategory
+from ..core.models import DetectedLicense, DetectionMethod, LicenseCategory, ScanTargets
 from ..core.input_processor import InputProcessor
 from ..data.spdx_licenses import SPDXLicenseData
 from .tlsh_detector import TLSHDetector
@@ -264,17 +264,8 @@ class LicenseDetector:
         if single_file_mode:
             files_to_scan = [path]
         else:
-            # Find potential license files
-            files_to_scan = self._find_license_files(path)
+            files_to_scan = self._find_files_to_scan(path, self.config.scan_targets())
 
-            # In default mode (license_files_only=True, strict_license_files=False),
-            # also scan metadata and README files
-            if self.config.license_files_only and not self.config.strict_license_files:
-                files_to_scan.extend(self._find_metadata_and_readme_files(path))
-            elif not self.config.license_files_only:
-                # Deep scan mode: scan all source files for embedded licenses
-                files_to_scan.extend(self._find_source_files(path))
-        
         logger.info(f"Scanning {len(files_to_scan)} files for licenses")
         
         # Process files in parallel for better performance
@@ -357,6 +348,68 @@ class LicenseDetector:
             logger.debug(f"Error in file {file_path}: {e}")
             return []
     
+    def _find_files_to_scan(self, directory: Path, targets: ScanTargets) -> List[Path]:
+        """Collect the files to scan for the enabled scan targets (issue #79)."""
+        files: Set[Path] = set()
+
+        if targets.license_files or targets.notice_files:
+            for file_path in self._find_license_files(directory):
+                if self._is_third_party_notice_file(file_path):
+                    if targets.notice_files:
+                        files.add(file_path)
+                elif targets.license_files:
+                    files.add(file_path)
+
+        if targets.source_files:
+            # A content scan enumerates every readable file, which sweeps up the
+            # other categories too, so disabled ones are filtered back out.
+            files.update(
+                file_path for file_path in self._find_source_files(directory)
+                if self._is_enabled_scan_target(file_path, targets)
+            )
+        elif targets.package_metadata or targets.documentation:
+            # Documentation extensions also cover notice files such as
+            # THIRD_PARTY_NOTICES.txt, so filter by category here too.
+            files.update(
+                file_path for file_path in self._find_metadata_and_documentation_files(
+                    directory,
+                    include_metadata=targets.package_metadata,
+                    include_documentation=targets.documentation,
+                )
+                if self._is_enabled_scan_target(file_path, targets)
+            )
+
+        # Sorted so that a scan reads files - and therefore reports evidence -
+        # in a stable order regardless of how the categories were collected.
+        return sorted(files)
+
+    def _is_enabled_scan_target(self, file_path: Path, targets: ScanTargets) -> bool:
+        """Whether a file's scan target category is enabled.
+
+        Categories are mutually exclusive and checked in precedence order: a
+        bundled third-party notice is a notice file rather than a license file,
+        and package metadata wins over the documentation extensions it shares
+        (``requirements.txt``).
+        """
+        if self._is_third_party_notice_file(file_path):
+            return targets.notice_files
+        if self._is_license_file(file_path):
+            return targets.license_files
+        if self._is_package_metadata_file(file_path):
+            return targets.package_metadata
+        if self._is_documentation_file(file_path):
+            return targets.documentation
+        return targets.source_files
+
+    def _is_package_metadata_file(self, file_path: Path) -> bool:
+        """Check if a file is a package manifest / lock file."""
+        return (file_path.name.lower() in self._PACKAGE_METADATA_FILENAMES
+                or file_path.suffix.lower() in self._PACKAGE_METADATA_EXTENSIONS)
+
+    def _is_documentation_file(self, file_path: Path) -> bool:
+        """Check if a file is readable documentation (README, *.md, *.rst, ...)."""
+        return file_path.suffix.lower() in self._DOCUMENTATION_EXTENSIONS
+
     def _find_license_files(self, directory: Path) -> List[Path]:
         """Find potential license files in directory."""
         license_files_set = set()  # Use set for O(1) lookup
@@ -384,73 +437,76 @@ class LicenseDetector:
 
         return list(license_files_set)
 
-    def _find_metadata_and_readme_files(self, directory: Path) -> List[Path]:
-        """Find README, package metadata, and other readable documentation files (.txt, .md, .rst, etc.)."""
-        metadata_files_set = set()  # Use set for O(1) lookup and automatic deduplication
+    # Readable documentation file extensions
+    _DOCUMENTATION_EXTENSIONS = {
+        '.txt', '.md', '.rst', '.text', '.markdown', '.adoc', '.asciidoc'
+    }
+
+    # Package metadata files (lowercase for exact name matches)
+    # Covers top 15+ package ecosystems
+    _PACKAGE_METADATA_FILENAMES = {
+        # JavaScript/Node.js (npm, yarn, pnpm)
+        'package.json', 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml',
+        # Python
+        'pyproject.toml', 'setup.py', 'setup.cfg', 'pipfile', 'pipfile.lock', 'requirements.txt',
+        # Go
+        'go.mod', 'go.sum',
+        # Java (Maven, Gradle)
+        'pom.xml', 'build.gradle', 'build.gradle.kts', 'settings.gradle', 'manifest.mf',
+        # .NET/NuGet
+        'packages.config', 'paket.dependencies',
+        # Rust
+        'cargo.toml', 'cargo.lock',
+        # Ruby
+        'gemfile', 'gemfile.lock',
+        # PHP/Composer
+        'composer.json', 'composer.lock',
+        # Swift/CocoaPods
+        'podfile', 'podfile.lock',
+        # Dart/Flutter
+        'pubspec.yaml', 'pubspec.lock',
+        # Elixir
+        'mix.exs', 'mix.lock',
+        # Scala
+        'build.sbt',
+        # Kotlin
+        'build.gradle.kts',
+    }
+
+    # Pattern-based metadata extensions
+    _PACKAGE_METADATA_EXTENSIONS = {
+        '.gemspec',   # Ruby
+        '.nuspec',    # NuGet
+        '.csproj',    # .NET C#
+        '.fsproj',    # .NET F#
+        '.vbproj',    # .NET VB
+        '.podspec',   # CocoaPods
+    }
+
+    def _find_metadata_and_documentation_files(self, directory: Path,
+                                               include_metadata: bool = True,
+                                               include_documentation: bool = True) -> List[Path]:
+        """Find package metadata and readable documentation files.
+
+        Both categories share a single directory walk because the default scan
+        wants both. Metadata is classified first, so a manifest that happens to
+        use a documentation extension (``requirements.txt``) follows the
+        metadata setting rather than the documentation one.
+        """
+        found: Set[Path] = set()
         scanner = SafeFileScanner(
             max_depth=self.config.max_recursion_depth,
             follow_symlinks=False
         )
 
-        # Readable documentation file extensions
-        doc_extensions = {'.txt', '.md', '.rst', '.text', '.markdown', '.adoc', '.asciidoc'}
-
-        # Package metadata files (pre-compute lowercase set for exact matches)
-        # Covers top 15+ package ecosystems
-        metadata_filenames_exact = {
-            # JavaScript/Node.js (npm, yarn, pnpm)
-            'package.json', 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml',
-            # Python
-            'pyproject.toml', 'setup.py', 'setup.cfg', 'pipfile', 'pipfile.lock', 'requirements.txt',
-            # Go
-            'go.mod', 'go.sum',
-            # Java (Maven, Gradle)
-            'pom.xml', 'build.gradle', 'build.gradle.kts', 'settings.gradle', 'manifest.mf',
-            # .NET/NuGet
-            'packages.config', 'paket.dependencies',
-            # Rust
-            'cargo.toml', 'cargo.lock',
-            # Ruby
-            'gemfile', 'gemfile.lock',
-            # PHP/Composer
-            'composer.json', 'composer.lock',
-            # Swift/CocoaPods
-            'podfile', 'podfile.lock',
-            # Dart/Flutter
-            'pubspec.yaml', 'pubspec.lock',
-            # Elixir
-            'mix.exs', 'mix.lock',
-            # Scala
-            'build.sbt',
-            # Kotlin
-            'build.gradle.kts',
-        }
-
-        # Pattern-based metadata extensions
-        metadata_extensions = {
-            '.gemspec',   # Ruby
-            '.nuspec',    # NuGet
-            '.csproj',    # .NET C#
-            '.fsproj',    # .NET F#
-            '.vbproj',    # .NET VB
-            '.podspec',   # CocoaPods
-        }
-
         for file_path in scanner.scan_directory(directory, '*'):
-            name_lower = file_path.name.lower()
-            ext_lower = file_path.suffix.lower()
+            if self._is_package_metadata_file(file_path):
+                if include_metadata:
+                    found.add(file_path)
+            elif include_documentation and self._is_documentation_file(file_path):
+                found.add(file_path)
 
-            # Check for readable documentation files by extension
-            if ext_lower in doc_extensions:
-                metadata_files_set.add(file_path)
-            # Check metadata files by exact name
-            elif name_lower in metadata_filenames_exact:
-                metadata_files_set.add(file_path)
-            # Check pattern-based metadata files by extension
-            elif ext_lower in metadata_extensions:
-                metadata_files_set.add(file_path)
-
-        return list(metadata_files_set)
+        return list(found)
     
     def _find_source_files(self, directory: Path, limit: int = -1) -> List[Path]:
         """Find all readable files to scan for embedded licenses."""
@@ -693,7 +749,17 @@ class LicenseDetector:
     def _detect_licenses_in_file(self, file_path: Path, single_file_mode: bool = False) -> List[DetectedLicense]:
         """Detect licenses in a single file."""
         licenses = []
-        
+
+        targets = self.config.scan_targets()
+
+        # A manifest declares its license in a syntax the generic tag detector
+        # also recognizes, so a file that is package metadata is skipped whole
+        # when metadata is disregarded - including a scan pointed straight at it
+        # (issue #79).
+        if not targets.package_metadata and self._is_package_metadata_file(file_path):
+            logger.debug(f"Skipping package metadata file: {file_path}")
+            return licenses
+
         # Read file content - for large files, read in chunks
         file_size = file_path.stat().st_size if file_path.exists() else 0
         
@@ -707,9 +773,12 @@ class LicenseDetector:
         if not content:
             return licenses
         
-        # Method 0: Extract from package metadata files first (highest priority)
-        metadata_licenses = self._extract_package_metadata(content, file_path)
-        licenses.extend(metadata_licenses)
+        # Method 0: Extract from package metadata files first (highest priority).
+        # Skipped when metadata is disregarded, so a scan cannot report declared
+        # licenses from a manifest it was told to ignore (issue #79).
+        if targets.package_metadata:
+            metadata_licenses = self._extract_package_metadata(content, file_path)
+            licenses.extend(metadata_licenses)
 
         # Method 1: Detect SPDX tags
         tag_licenses = self._detect_spdx_tags(content, file_path)
@@ -1943,26 +2012,30 @@ class LicenseDetector:
         Returns:
             Detected license or None
         """
-        # Tier 0: Exact hash matching (SHA-256 and MD5)
-        detected = self._tier0_exact_hash(text, file_path)
-        if detected:
-            return detected
-        
-        # Tier 1: Dice-Sørensen similarity
-        detected = self._tier1_dice_sorensen(text, file_path)
-        if detected and detected.confidence >= self.config.similarity_threshold:
-            return detected
-        
-        # Tier 2: TLSH fuzzy hashing
-        detected = self.tlsh_detector.detect_license_tlsh(text, file_path)
-        if detected and detected.confidence >= self.config.similarity_threshold:
-            return detected
-        
+        # Tiers 0-2 compare the text against all SPDX license texts, which is
+        # the expensive part of a content scan; a lightweight scan skips them
+        # and relies on tags, keywords and references instead (issue #79).
+        if self.config.text_similarity_matching:
+            # Tier 0: Exact hash matching (SHA-256 and MD5)
+            detected = self._tier0_exact_hash(text, file_path)
+            if detected:
+                return detected
+
+            # Tier 1: Dice-Sørensen similarity
+            detected = self._tier1_dice_sorensen(text, file_path)
+            if detected and detected.confidence >= self.config.similarity_threshold:
+                return detected
+
+            # Tier 2: TLSH fuzzy hashing
+            detected = self.tlsh_detector.detect_license_tlsh(text, file_path)
+            if detected and detected.confidence >= self.config.similarity_threshold:
+                return detected
+
         # Tier 3: Regex pattern matching
         detected = self._tier3_regex_matching(text, file_path)
         if detected:
             return detected
-        
+
         # No match found
         return None
     

--- a/osslili/extractors/copyright_extractor.py
+++ b/osslili/extractors/copyright_extractor.py
@@ -130,12 +130,13 @@ class CopyrightExtractor:
         # Sort by confidence
         copyrights.sort(key=lambda x: x.confidence, reverse=True)
         
-        # Also check package metadata
-        metadata_copyrights = self._extract_from_metadata(path)
-        for mc in metadata_copyrights:
-            if mc.statement not in processed_statements:
-                processed_statements.add(mc.statement)
-                copyrights.append(mc)
+        # Also check package metadata, unless metadata is disregarded (issue #79)
+        if self.config.scan_targets().package_metadata:
+            metadata_copyrights = self._extract_from_metadata(path)
+            for mc in metadata_copyrights:
+                if mc.statement not in processed_statements:
+                    processed_statements.add(mc.statement)
+                    copyrights.append(mc)
         
         return copyrights
     

--- a/tests/test_scan_targets.py
+++ b/tests/test_scan_targets.py
@@ -1,0 +1,381 @@
+"""Tests for fine-grained scan targets and scanning-mode presets (issue #79).
+
+Scanning modes are presets over per-category scan targets (license files,
+bundled notice files, package metadata, documentation, source files), so a
+consumer that gets declared licenses elsewhere - ORT's analyzer, for example -
+can scan all files while disregarding package metadata.
+"""
+
+from pathlib import Path
+
+import json
+import pytest
+from click.testing import CliRunner
+
+from osslili.cli import main
+from osslili.core.models import SCAN_MODES, Config, ScanTargets
+from osslili.core.generator import LicenseCopyrightDetector
+from osslili.detectors.license_detector import LicenseDetector
+
+
+MIT_TEXT = """MIT License
+
+Copyright (c) 2024 Project Author
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A project with one file per scan target category."""
+    (tmp_path / "LICENSE").write_text(MIT_TEXT)
+    (tmp_path / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "demo",
+                "version": "1.0.0",
+                "license": "Apache-2.0",
+                "author": "Metadata Corp <legal@metadata.example>",
+            }
+        )
+    )
+    (tmp_path / "README.md").write_text(
+        "# Demo\n\nThis project is licensed under the MIT License.\n"
+    )
+    (tmp_path / "requirements.txt").write_text("requests>=2.0\n")
+    (tmp_path / "THIRD_PARTY_NOTICES.txt").write_text(
+        "This product bundles zlib.\n\nSPDX-License-Identifier: Zlib\n"
+    )
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.py").write_text(
+        "# SPDX-License-Identifier: BSD-3-Clause\n"
+        "# Copyright (c) 2024 Source Author\n\n"
+        "def main():\n    pass\n"
+    )
+    return tmp_path
+
+
+def scanned_files(config: Config, path: Path) -> set:
+    """Names of the files a configuration would scan for licenses."""
+    detector = LicenseDetector(config)
+    return {p.name for p in detector._find_files_to_scan(path, config.scan_targets())}
+
+
+def source_files(licenses) -> set:
+    return {Path(l.source_file).name for l in licenses if l.source_file}
+
+
+# --------------------------------------------------------------------------
+# Scan target resolution
+# --------------------------------------------------------------------------
+
+
+def test_default_targets_exclude_source_files():
+    targets = Config().scan_targets()
+    assert targets == ScanTargets(
+        license_files=True,
+        notice_files=True,
+        package_metadata=True,
+        documentation=True,
+        source_files=False,
+    )
+
+
+def test_default_config_keeps_text_similarity_matching():
+    assert Config().text_similarity_matching is True
+
+
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        (
+            "default",
+            ScanTargets(
+                license_files=True,
+                notice_files=True,
+                package_metadata=True,
+                documentation=True,
+                source_files=False,
+            ),
+        ),
+        (
+            "deep",
+            ScanTargets(
+                license_files=True,
+                notice_files=True,
+                package_metadata=True,
+                documentation=True,
+                source_files=True,
+            ),
+        ),
+        (
+            "license-files",
+            ScanTargets(
+                license_files=True,
+                notice_files=True,
+                package_metadata=False,
+                documentation=False,
+                source_files=False,
+            ),
+        ),
+        (
+            "lightweight",
+            ScanTargets(
+                license_files=True,
+                notice_files=True,
+                package_metadata=False,
+                documentation=True,
+                source_files=True,
+            ),
+        ),
+    ],
+)
+def test_scan_mode_presets(mode, expected):
+    config = Config()
+    config.apply_scan_mode(mode)
+    assert config.scan_targets() == expected
+
+
+def test_lightweight_mode_disables_text_similarity_matching():
+    config = Config()
+    config.apply_scan_mode("lightweight")
+    assert config.text_similarity_matching is False
+
+
+@pytest.mark.parametrize("mode", [m for m in SCAN_MODES if m != "lightweight"])
+def test_other_modes_keep_text_similarity_matching(mode):
+    config = Config()
+    config.apply_scan_mode(mode)
+    assert config.text_similarity_matching is True
+
+
+def test_unknown_scan_mode_is_rejected():
+    with pytest.raises(ValueError, match="Unknown scan mode"):
+        Config().apply_scan_mode("thorough")
+
+
+def test_legacy_mode_flags_still_resolve_to_targets():
+    assert Config(deep_scan=True).scan_targets().source_files is True
+    assert Config(license_files_only=False).scan_targets().source_files is True
+    strict = Config(strict_license_files=True).scan_targets()
+    assert (strict.package_metadata, strict.documentation) == (False, False)
+
+
+def test_explicit_target_overrides_win_over_the_mode():
+    config = Config()
+    config.apply_scan_mode("deep")
+    config.scan_package_metadata = False
+    targets = config.scan_targets()
+    assert targets.package_metadata is False
+    assert targets.source_files is True
+
+    # ... and the other way around: metadata back on in lightweight mode.
+    config = Config()
+    config.apply_scan_mode("lightweight")
+    config.scan_package_metadata = True
+    assert config.scan_targets().package_metadata is True
+
+
+# --------------------------------------------------------------------------
+# File selection
+# --------------------------------------------------------------------------
+
+
+def test_default_mode_scans_license_metadata_and_documentation(project):
+    scanned = scanned_files(Config(), project)
+    assert {"LICENSE", "package.json", "README.md", "THIRD_PARTY_NOTICES.txt"} <= scanned
+    assert "app.py" not in scanned
+
+
+def test_deep_mode_scans_source_files_and_metadata(project):
+    config = Config()
+    config.apply_scan_mode("deep")
+    scanned = scanned_files(config, project)
+    assert {"LICENSE", "package.json", "README.md", "app.py"} <= scanned
+
+
+def test_disabling_package_metadata_keeps_every_other_file(project):
+    config = Config()
+    config.apply_scan_mode("deep")
+    config.scan_package_metadata = False
+    scanned = scanned_files(config, project)
+    assert "package.json" not in scanned
+    # requirements.txt is package metadata even though it has a doc extension
+    assert "requirements.txt" not in scanned
+    assert {"LICENSE", "README.md", "app.py"} <= scanned
+
+
+def test_lightweight_mode_scans_all_files_without_metadata(project):
+    config = Config()
+    config.apply_scan_mode("lightweight")
+    scanned = scanned_files(config, project)
+    assert "package.json" not in scanned
+    assert {"LICENSE", "README.md", "app.py"} <= scanned
+
+
+def test_disabling_documentation_keeps_license_files(project):
+    config = Config()
+    config.scan_documentation = False
+    scanned = scanned_files(config, project)
+    assert "README.md" not in scanned
+    assert "LICENSE" in scanned
+
+
+def test_disabling_notice_files_keeps_project_license_files(project):
+    config = Config()
+    config.scan_notice_files = False
+    scanned = scanned_files(config, project)
+    assert "THIRD_PARTY_NOTICES.txt" not in scanned
+    assert "LICENSE" in scanned
+
+
+def test_disabling_license_files_keeps_notice_files(project):
+    config = Config()
+    config.scan_license_files = False
+    scanned = scanned_files(config, project)
+    assert "LICENSE" not in scanned
+    assert "THIRD_PARTY_NOTICES.txt" in scanned
+
+
+def test_license_files_mode_scans_license_files_only(project):
+    config = Config()
+    config.apply_scan_mode("license-files")
+    scanned = scanned_files(config, project)
+    assert "package.json" not in scanned
+    assert "README.md" not in scanned
+    assert "app.py" not in scanned
+    assert "LICENSE" in scanned
+
+
+# --------------------------------------------------------------------------
+# Detection
+# --------------------------------------------------------------------------
+
+
+def test_default_mode_reports_metadata_declared_license(project):
+    licenses = LicenseDetector(Config()).detect_licenses(project)
+    assert "Apache-2.0" in {l.spdx_id for l in licenses}
+    assert "package.json" in source_files(licenses)
+
+
+def test_disabling_package_metadata_drops_metadata_licenses(project):
+    config = Config()
+    config.scan_package_metadata = False
+    licenses = LicenseDetector(config).detect_licenses(project)
+    assert "package.json" not in source_files(licenses)
+    assert "MIT" in {l.spdx_id for l in licenses}
+
+
+def test_disabling_package_metadata_applies_to_single_file_scans(project):
+    config = Config()
+    config.scan_package_metadata = False
+    licenses = LicenseDetector(config).detect_licenses(project / "package.json")
+    assert licenses == []
+
+
+def test_lightweight_mode_detects_source_tags_without_metadata(project):
+    config = Config()
+    config.apply_scan_mode("lightweight")
+    licenses = LicenseDetector(config).detect_licenses(project)
+    spdx_ids = {l.spdx_id for l in licenses}
+    assert "BSD-3-Clause" in spdx_ids  # SPDX tag in src/app.py
+    assert "Apache-2.0" not in spdx_ids  # declared in package.json only
+    assert "package.json" not in source_files(licenses)
+
+
+def test_disabling_text_similarity_skips_full_text_comparison(project):
+    config = Config()
+    config.text_similarity_matching = False
+    licenses = LicenseDetector(config).detect_licenses(project)
+    methods = {l.detection_method for l in licenses}
+    assert not methods & {"hash", "dice-sorensen", "tlsh"}
+    # The cheap detectors still run.
+    assert licenses
+    assert methods <= {"tag", "regex", "keyword", "filename"}
+
+
+def test_text_similarity_matching_is_on_by_default(project):
+    licenses = LicenseDetector(Config()).detect_licenses(project)
+    methods = {l.detection_method for l in licenses}
+    assert methods & {"hash", "dice-sorensen", "tlsh"}
+
+
+def test_disabling_package_metadata_drops_metadata_copyrights(project):
+    config = Config()
+    config.scan_package_metadata = False
+    result = LicenseCopyrightDetector(config).process_local_path(str(project))
+    holders = " ".join(c.holder for c in result.copyrights)
+    assert "Metadata Corp" not in holders
+
+    with_metadata = LicenseCopyrightDetector(Config()).process_local_path(str(project))
+    assert "Metadata Corp" in " ".join(c.holder for c in with_metadata.copyrights)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def test_cli_no_package_metadata_excludes_metadata_evidence(project):
+    result = CliRunner().invoke(
+        main, [str(project), "--deep", "--no-package-metadata", "-f", "evidence"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "package.json" not in result.output
+
+
+def test_cli_scan_mode_lightweight_excludes_metadata_evidence(project):
+    result = CliRunner().invoke(
+        main, [str(project), "--scan-mode", "lightweight", "-f", "evidence"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "package.json" not in result.output
+
+
+def test_cli_default_run_includes_metadata_evidence(project):
+    result = CliRunner().invoke(main, [str(project), "-f", "evidence"])
+    assert result.exit_code == 0, result.output
+    assert "package.json" in result.output
+
+
+def test_cli_rejects_conflicting_mode_flags(project):
+    result = CliRunner().invoke(main, [str(project), "--scan-mode", "deep", "--license-files-only"])
+    assert result.exit_code == 2
+    assert "--scan-mode" in result.output
+
+
+def test_cli_rejects_deep_together_with_license_files_only(project):
+    result = CliRunner().invoke(main, [str(project), "--deep", "--license-files-only"])
+    assert result.exit_code == 2
+
+
+def test_cli_scan_mode_deep_matches_the_deep_flag(project):
+    mode_run = CliRunner().invoke(main, [str(project), "--scan-mode", "deep"])
+    flag_run = CliRunner().invoke(main, [str(project), "--deep"])
+    assert mode_run.exit_code == 0, mode_run.output
+    assert flag_run.exit_code == 0, flag_run.output
+    assert _evidence_summary(mode_run.output) == _evidence_summary(flag_run.output)
+
+
+def _evidence_summary(output: str) -> dict:
+    """The scan summary from evidence output, ignoring per-detection ordering."""
+    payload = json.loads(output[output.index("{"):])
+    return payload["summary"]


### PR DESCRIPTION
## Summary

Closes #79.

A scanner running inside a pipeline that already reads declared licenses from package metadata — ORT, which strictly separates declared (metadata) from detected (source) licenses — repeats that cheap step for nothing and has no way to turn it off. Following the plan in the issue thread, this takes the fine-grained route rather than adding a single one-off switch: scanning modes become presets over individual scan targets, and the combination ORT wants is added as its own mode.

## What changed

**Scan targets.** New `ScanTargets`, resolved from the scanning mode plus explicit per-category overrides: license files, bundled notice files (the `THIRD_PARTY` category from #78), package metadata, documentation, source files. `Config.apply_scan_mode()` applies a preset; any `scan_*` target left as `None` follows the mode.

| Mode | license | notice | metadata | docs | source | full text comparison |
|------|---------|--------|----------|------|--------|----------------------|
| `default` | ✓ | ✓ | ✓ | ✓ | | ✓ |
| `deep` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| `license-files` | ✓ | ✓ | | | | ✓ |
| `lightweight` | ✓ | ✓ | | ✓ | ✓ | |

**Lightweight mode.** All files, package metadata disregarded, no full text comparison. As noted in the issue thread, skipping metadata is not where the time goes — tiers 0–2 (exact hash, Dice-Sørensen, TLSH) compare nearly every file against all 700+ SPDX license texts, and that is the cost. Lightweight keeps SPDX tags, keywords and references only. On osslili's own package directory it reads the same 30 files as `--deep` in 0.08s instead of 12.2s.

**Detection depth is its own switch** (`--text-similarity` / `--no-text-similarity`), so the heavier matching can be kept in lightweight mode or dropped from any other mode:

```bash
osslili . --deep --no-package-metadata            # deep, metadata disregarded
osslili . --scan-mode lightweight --text-similarity  # lightweight, accurate matching kept
```

**CLI.** `--scan-mode` (alias `--mode`) with `default`, `deep`, `license-files`, `lightweight`, plus `--license-files/--no-license-files`, `--notice-files/--no-notice-files`, `--package-metadata/--no-package-metadata`, `--documentation/--no-documentation`, `--source-files/--no-source-files`, `--text-similarity/--no-text-similarity`. Each target flag overrides the selected mode.

**Disregarding metadata is thorough.** It suppresses metadata-derived licenses *and* copyright holders, not just file selection: a manifest declares its license in a syntax the generic SPDX tag detector also recognizes, so a package metadata file is skipped whole — including a scan pointed straight at `package.json`. A manifest that shares a documentation extension (`requirements.txt`) counts as metadata rather than documentation.

## Compatibility

- `--deep` and `--license-files-only` remain supported as aliases for their modes; `deep_scan` / `license_files_only` / `strict_license_files` still resolve to the right targets for library users.
- One deliberate behavior change: passing flags that select **different** modes (`--deep --license-files-only`, or `--scan-mode` conflicting with either) is now a usage error. Previously the contradiction resolved silently to deep.
- Default, deep and license-files scans produce identical results — verified by comparing order-normalized evidence output (licenses, copyrights, summary) across three directories before and after the change. Report ordering is nondeterministic in both, from thread completion order; that is pre-existing.
- Copyright file selection is otherwise unchanged: the extractor always scanned source headers regardless of mode, and this PR only gates its package metadata step.

## Tests

`tests/test_scan_targets.py`, 34 new tests: target resolution per mode, override precedence, file selection per category, metadata suppression in directory and single-file scans, text-similarity gating (asserting no `hash`/`dice-sorensen`/`tlsh` detections while the cheap detectors still fire), metadata copyright suppression, and CLI behavior including the mode-conflict usage error. Full suite: 141 passed.

## Not included

Path-based third-party notice detection (a bare `LICENSE` under a `third_party/` directory) was parked in #87 for "the scan-mode work". It is a categorization-accuracy change to #78's semantics rather than part of the scan target selection here, so it is left open — happy to add it in this PR or a follow-up.

Separately noticed while working here: `_extract_from_pyproject_toml` calls `self._detect_from_full_text(...)`, which does not exist, so the PEP 639 `license = {file = "LICENSE"}` path silently yields nothing (the `AttributeError` is swallowed by the surrounding `except Exception`). Left untouched as unrelated; worth its own issue.
