### PR TITLE
Stop matchers asserting licenses the text does not carry (#90, #91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to osslili will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **TLSH matcher reported near-identical licenses as declared** (Issue #90): the matcher returned its nearest fuzzy-hash neighbour as the verdict at a confidence floored at 0.97, which outranked the matchers that had the file right. TLSH measures bulk document similarity, so licenses that differ by a single clause are indistinguishable to it — canonical MIT text sits closer to the JSON license (distance 17) than to MIT itself (29), and those clauses are exactly what changes the obligations
+  - TLSH is now a candidate generator: every near neighbour within the distance threshold is collected, and a candidate is only asserted once its actual license text corroborates the scanned text (Dice-Sørensen ≥ 0.9)
+  - A proposal that cannot be substantiated — most bundled SPDX entries ship no license text — is dropped rather than reported, leaving the answer to the tiers that can back it up
+  - Reported confidence is now the measured text agreement instead of a fixed floor, so a fuzzy match no longer outranks an exact or keyword identification of the same file
+  - Observed effect: MIT no longer reported as `JSON`, BSD-3-Clause no longer reported as `BSD-4-Clause` or `BSD-3-Clause-HP`
+- **Keyword matcher asserted licenses from prose that only discusses them** (Issue #91): the PSF license stack explains at length how Python relates to the GPL while being distributed under Python-2.0, and a keyword hit on that commentary asserted `GPL-2.0-or-later` — copyleft claimed over a permissive package
+  - Mentions framed as compatibility notes, license history, exclusions, or linking exceptions no longer count as a grant
+  - All occurrences of a keyword are now examined rather than only the first, so rejecting a mention means "keep looking" instead of giving up on the file
+  - An unversioned "GPL" / "General Public License" mention yields no identifier: it names a family, and GPL-2.0-only and GPL-3.0-only are mutually incompatible, so resolving it to either invents an obligation. The previous fallback guessed `GPL-2.0-or-later`, and its version sniffer accepted any digit in the surrounding window — a copyright year read as a version
+  - Keyword variations now match on word boundaries; `MIT` was matching inside "per**mit**ted" and "li**mit**ation", which run throughout the LGPL and MPL texts
+
+### Technical Details
+- Added `TLSHDetector._find_near_neighbours()` and `TLSHDetector._corroborate()`; the tier-2 gate in `_detect_license_from_text` no longer re-checks `similarity_threshold`, which was a no-op against the old confidence floor
+- Extracted `create_bigrams()` / `dice_coefficient()` into `osslili/utils/text_similarity.py`, shared by the Dice-Sørensen and TLSH tiers
+- Added `tests/test_matcher_accuracy.py` covering both issues
+
 ## [1.7.0] - 2026-07-24
 
 ### Added

--- a/osslili/detectors/license_detector.py
+++ b/osslili/detectors/license_detector.py
@@ -2,6 +2,7 @@
 License detection module with multi-tier detection system.
 """
 
+import itertools
 import logging
 import re
 import fnmatch
@@ -19,6 +20,7 @@ from .tlsh_detector import TLSHDetector
 from ..utils.file_scanner import SafeFileScanner
 from ..utils.license_normalizer import LicenseNormalizer
 from ..utils.regex_matcher import RegexPatternMatcher
+from ..utils.text_similarity import create_bigrams, dice_coefficient
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +29,81 @@ logger = logging.getLogger(__name__)
 # ambiguous about whether later license versions are permitted. This matches a
 # bare GNU-family id so it can be mapped to its modern replacement.
 _DEPRECATED_GNU_RE = re.compile(r'^(?:A?GPL|LGPL|GFDL)-\d+(?:\.\d+)?$')
+
+# Prose that *discusses* a license instead of granting it: compatibility notes,
+# license history, explicit exclusions, and linking exceptions that name a
+# library's license only to carve it out. A license name in a sentence like
+# this says nothing about the terms the file carries. The PSF license stack is
+# the motivating case — it explains at length how Python relates to the GPL
+# while the package itself is Python-2.0, and a keyword hit on that prose used
+# to assert copyleft over a permissive package (issue #91).
+_LICENSE_DISCUSSION_RE = re.compile(
+    r'compatib'                                                   # GPL-compatible, compatibility
+    r'|incompatib'
+    r'|unlike\s+th(?:e|is)\b'
+    r'|(?:previously|formerly|originally)\s+(?:distributed|released|licen[sc]ed)'
+    r'|does\s+not\s+mean\b'
+    r'|(?:is|are|was|were)\s+not\s+(?:distributed|released|licen[sc]ed)\b'
+    r'|as\s+a\s+special\s+exception'                              # linking exceptions
+    r'|permission\s+to\s+link'
+    r'|linking\s+exception',
+    re.IGNORECASE,
+)
+
+# Cap on how far the discussion scan reaches from a match when the text has no
+# paragraph breaks to bound it.
+_DISCUSSION_SPAN_LIMIT = 400
+
+# An explicit GNU version, as it is actually written: "v2", "version 3",
+# "GPL-2.0", "GPLv3". A bare digit anywhere nearby is not a version — a
+# copyright year or a section number would do just as well — so an unversioned
+# mention yields no identifier at all rather than a guessed one.
+_GNU_VERSION_RE = re.compile(
+    r'(?:GPL|General\s+Public\s+License)[\s,-]*v?(?:ersion\s*)?([123])(?:\.\d+)?\b'
+    r'|\bv(?:ersion\s*)?([123])(?:\.\d+)?\s*(?:of\s+the\s+)?(?:GNU\s+)?(?:GPL|General\s+Public\s+License)',
+    re.IGNORECASE,
+)
+
+# The number of occurrences of a single keyword variation examined per file.
+# Bounds the cost on pathological inputs while leaving room to skip over
+# discussion prose to a real grant later in the same file.
+_MAX_KEYWORD_OCCURRENCES = 50
+
+
+def _paragraph_around(content: str, start: int, end: int) -> str:
+    """Return the paragraph containing content[start:end].
+
+    Discussion qualifiers govern their own paragraph: a linking exception names
+    the library it carves out a sentence or two after "as a special exception",
+    while the heading that states a file's real license sits in a paragraph of
+    its own. A fixed character window cannot tell those apart — it either
+    reaches too short to catch the exception or far enough to swallow the
+    heading in a densely packed aggregate license file.
+    """
+    paragraph_start = content.rfind('\n\n', 0, start)
+    paragraph_start = 0 if paragraph_start == -1 else paragraph_start + 2
+
+    paragraph_end = content.find('\n\n', end)
+    paragraph_end = len(content) if paragraph_end == -1 else paragraph_end
+
+    return content[
+        max(paragraph_start, start - _DISCUSSION_SPAN_LIMIT):
+        min(paragraph_end, end + _DISCUSSION_SPAN_LIMIT)
+    ]
+
+
+def _bounded_pattern(variation: str) -> str:
+    """Build a whole-word regex for a license keyword variation.
+
+    Without word boundaries a short identifier matches inside ordinary words —
+    "MIT" occurs in "permitted" and "limitation", which appear throughout the
+    LGPL and MPL texts. Boundaries are only added on sides that end in a word
+    character, so variations bounded by punctuation (e.g. "MIT/X11") still
+    match.
+    """
+    prefix = r'\b' if variation[:1].isalnum() or variation[:1] == '_' else ''
+    suffix = r'\b' if variation[-1:].isalnum() or variation[-1:] == '_' else ''
+    return prefix + re.escape(variation) + suffix
 
 
 class LicenseDetector:
@@ -1611,67 +1688,94 @@ class LicenseDetector:
 
             # Check exact matches first
             for variation in variations:
-                if variation.lower() in content.lower():
-                    # Check context
-                    pattern_re = re.compile(re.escape(variation), re.IGNORECASE)
-                    match = pattern_re.search(content)
-                    if match:
-                        # Check if it appears in a license context
-                        start = max(0, match.start() - 100)
-                        end = min(len(content), match.end() + 50)
-                        context = content[start:end]
-                        has_context = any(re.search(pattern, context, re.IGNORECASE) for pattern in context_patterns)
+                if variation.lower() not in content.lower():
+                    continue
 
-                        # Check for comment or line start (more strict)
-                        line_start = False
-                        if match.start() > 0:
-                            # Look at the entire line leading up to the match
-                            line_start_pos = content.rfind('\n', 0, match.start())
-                            if line_start_pos == -1:
-                                line_start_pos = 0
-                            else:
-                                line_start_pos += 1
-                            line_prefix = content[line_start_pos:match.start()].strip()
+                pattern_re = re.compile(_bounded_pattern(variation), re.IGNORECASE)
 
-                            # Check if line starts with comment markers or license-related keywords
-                            comment_markers = ['#', '//', '/*', '*', '--', '%', ';']
-                            license_keywords = ['license', 'copyright', '©', 'spdx', 'distributed under', 'licensed under']
+                # Walk every occurrence rather than only the first. A license
+                # file may mention a license in passing (compatibility notes,
+                # history) well before it states the terms it actually grants,
+                # so rejecting an occurrence has to mean "keep looking", not
+                # "give up on this variation".
+                for match in itertools.islice(pattern_re.finditer(content), _MAX_KEYWORD_OCCURRENCES):
+                    # Check if it appears in a license context
+                    start = max(0, match.start() - 100)
+                    end = min(len(content), match.end() + 50)
+                    context = content[start:end]
 
-                            line_start = (
-                                any(line_prefix.startswith(marker) for marker in comment_markers) or
-                                any(keyword in line_prefix.lower() for keyword in license_keywords) or
-                                line_prefix == ''
-                            )
+                    # Skip mentions that discuss a license rather than grant it
+                    paragraph = _paragraph_around(content, match.start(), match.end())
+                    if _LICENSE_DISCUSSION_RE.search(paragraph):
+                        logger.debug(
+                            f"Skipping '{variation}' in {file_path}: mention is "
+                            f"discussion, not a grant"
+                        )
+                        continue
+
+                    has_context = any(re.search(pattern, context, re.IGNORECASE) for pattern in context_patterns)
+
+                    # Check for comment or line start (more strict)
+                    line_start = False
+                    if match.start() > 0:
+                        # Look at the entire line leading up to the match
+                        line_start_pos = content.rfind('\n', 0, match.start())
+                        if line_start_pos == -1:
+                            line_start_pos = 0
                         else:
-                            line_start = True
+                            line_start_pos += 1
+                        line_prefix = content[line_start_pos:match.start()].strip()
 
-                        # Only match if we have strong license context or it's in a clear license statement
-                        if has_context and line_start:
-                            # Handle version suffixes and normalization
-                            final_spdx_id = handle_version_suffix(spdx_id, content[match.start():match.end()+20])
+                        # Check if line starts with comment markers or license-related keywords
+                        comment_markers = ['#', '//', '/*', '*', '--', '%', ';']
+                        license_keywords = ['license', 'copyright', '©', 'spdx', 'distributed under', 'licensed under']
 
-                            # Normalize generic GPL to GPL-2.0-or-later if no version specified
-                            if final_spdx_id == 'GPL':
-                                # Look for version hints nearby
-                                context_text = content[max(0, match.start()-100):min(len(content), match.end()+100)]
-                                if '3' in context_text or 'v3' in context_text or 'version 3' in context_text.lower():
-                                    final_spdx_id = 'GPL-3.0'
-                                elif '2' in context_text or 'v2' in context_text or 'version 2' in context_text.lower():
-                                    final_spdx_id = 'GPL-2.0'
-                                else:
-                                    final_spdx_id = 'GPL-2.0-or-later'  # Default for generic GPL
+                        line_start = (
+                            any(line_prefix.startswith(marker) for marker in comment_markers) or
+                            any(keyword in line_prefix.lower() for keyword in license_keywords) or
+                            line_prefix == ''
+                        )
+                    else:
+                        line_start = True
 
-                            licenses.append(DetectedLicense(
-                                spdx_id=final_spdx_id,
-                                name=final_spdx_id,
-                                confidence=0.85,
-                                detection_method=DetectionMethod.KEYWORD.value,
-                                source_file=str(file_path),
-                                category='detected',
-                                match_type='keyword'
-                            ))
-                            found_licenses.add(spdx_id)
-                            break
+                    # Only match if we have strong license context or it's in a clear license statement
+                    if not (has_context and line_start):
+                        continue
+
+                    # Handle version suffixes and normalization
+                    final_spdx_id = handle_version_suffix(spdx_id, content[match.start():match.end()+20])
+
+                    # Resolve a generic "GPL" / "General Public License" mention
+                    # to a versioned id. Without an explicit version the mention
+                    # names a license family, not a license: GPL-2.0-only and
+                    # GPL-3.0-only are mutually incompatible, so guessing one
+                    # invents an obligation. Report nothing instead.
+                    if final_spdx_id == 'GPL':
+                        context_text = content[max(0, match.start()-100):min(len(content), match.end()+100)]
+                        version_match = _GNU_VERSION_RE.search(context_text)
+                        if not version_match:
+                            logger.debug(
+                                f"Skipping unversioned GPL mention in {file_path}: "
+                                f"no explicit version to resolve it to"
+                            )
+                            continue
+                        version = version_match.group(1) or version_match.group(2)
+                        final_spdx_id = f'GPL-{version}.0'
+
+                    licenses.append(DetectedLicense(
+                        spdx_id=final_spdx_id,
+                        name=final_spdx_id,
+                        confidence=0.85,
+                        detection_method=DetectionMethod.KEYWORD.value,
+                        source_file=str(file_path),
+                        category='detected',
+                        match_type='keyword'
+                    ))
+                    found_licenses.add(spdx_id)
+                    break
+
+                if spdx_id in found_licenses:
+                    break
 
             # If no exact match, try fuzzy matching for common typos
             if spdx_id not in found_licenses and spdx_id in ['MIT', 'Apache-2.0', 'GPL-2.0', 'GPL-3.0']:
@@ -1953,9 +2057,13 @@ class LicenseDetector:
         if detected and detected.confidence >= self.config.similarity_threshold:
             return detected
         
-        # Tier 2: TLSH fuzzy hashing
+        # Tier 2: TLSH fuzzy hashing. The detector applies its own bar — a
+        # proposed near neighbour is only returned once the license's real text
+        # corroborates it — so anything it returns is accepted here. Gating on
+        # similarity_threshold instead would be a no-op, because TLSH used to
+        # floor its confidence at exactly that value (issue #90).
         detected = self.tlsh_detector.detect_license_tlsh(text, file_path)
-        if detected and detected.confidence >= self.config.similarity_threshold:
+        if detected:
             return detected
         
         # Tier 3: Regex pattern matching
@@ -2100,21 +2208,12 @@ class LicenseDetector:
     
     def _create_bigrams(self, text: str) -> Set[str]:
         """Create character bigrams from text."""
-        bigrams = set()
-        
-        for i in range(len(text) - 1):
-            bigrams.add(text[i:i+2])
-        
-        return bigrams
-    
+        return create_bigrams(text)
+
     def _dice_coefficient(self, set1: Set[str], set2: Set[str]) -> float:
         """Calculate Dice-Sørensen coefficient between two sets."""
-        if not set1 or not set2:
-            return 0.0
-        
-        intersection = len(set1 & set2)
-        return (2.0 * intersection) / (len(set1) + len(set2))
-    
+        return dice_coefficient(set1, set2)
+
     def _adjust_regex_confidence(self, raw_score: float, category: str, match_type: str, match_count: int) -> float:
         """
         Adjust confidence scores for regex-based license detection based on context.

--- a/osslili/detectors/tlsh_detector.py
+++ b/osslili/detectors/tlsh_detector.py
@@ -8,8 +8,23 @@ from pathlib import Path
 from typing import Optional, Dict, Any
 
 from ..core.models import DetectedLicense, DetectionMethod, LicenseCategory
+from ..utils.text_similarity import create_bigrams, dice_coefficient
 
 logger = logging.getLogger(__name__)
+
+# TLSH distance under which two texts count as near neighbours. TLSH is a
+# locality-sensitive hash over the whole document, so it measures bulk
+# similarity: excellent at finding which licenses a text resembles, useless at
+# telling those licenses apart. Canonical MIT text, for instance, sits closer
+# to the JSON license (distance 17) than to MIT itself (29), because JSON is
+# MIT plus one sentence and that sentence offsets the length difference of a
+# package's own copyright line. See issue #90.
+NEAR_NEIGHBOUR_DISTANCE = 30
+
+# Minimum Dice-Sørensen agreement between the scanned text and a candidate's
+# actual license text before that candidate may be asserted. Matches the bar
+# the Dice-Sørensen tier applies to its own matches.
+CORROBORATION_THRESHOLD = 0.9
 
 # Try to import tlsh, make it optional
 try:
@@ -132,87 +147,143 @@ class TLSHDetector:
         
         return text
     
+    def _find_near_neighbours(self, input_hash: str) -> list:
+        """
+        Find every known license whose TLSH hash is a near neighbour of the input.
+
+        Args:
+            input_hash: TLSH hash of the preprocessed scanned text
+
+        Returns:
+            List of (distance, license_id) tuples, closest first
+        """
+        neighbours = []
+
+        for license_id, hash_data in self.license_hashes.items():
+            try:
+                distance = tlsh.diff(input_hash, hash_data['hash'])
+            except Exception as e:
+                logger.debug(f"Error comparing TLSH hashes for {license_id}: {e}")
+                continue
+
+            if distance <= NEAR_NEIGHBOUR_DISTANCE:
+                neighbours.append((distance, license_id))
+
+        neighbours.sort()
+        return neighbours
+
+    def _corroborate(self, text: str, candidates: list) -> Optional[tuple]:
+        """
+        Pick the candidate whose real license text best agrees with the scanned text.
+
+        TLSH proximity alone cannot separate licenses that differ by a single
+        clause, and those clauses carry the obligations that matter (the JSON
+        license is MIT plus "Good, not Evil"; BSD-4-Clause is BSD-3-Clause plus
+        the advertising clause). So a candidate is only accepted once the
+        license's own text confirms it.
+
+        Args:
+            text: The scanned text
+            candidates: (distance, license_id) tuples from _find_near_neighbours
+
+        Returns:
+            (license_id, similarity) for the best corroborated candidate, or
+            None when no candidate's text can substantiate the match
+        """
+        input_bigrams = create_bigrams(self.spdx_data._normalize_text(text))
+        if not input_bigrams:
+            return None
+
+        best = None
+
+        for _distance, license_id in candidates:
+            license_text = self.spdx_data.get_license_text(license_id)
+            if not license_text:
+                # No text bundled or cached for this id, so the proposal cannot
+                # be checked. Silence beats an unverifiable license assertion.
+                logger.debug(f"No license text available to corroborate {license_id}")
+                continue
+
+            license_bigrams = create_bigrams(self.spdx_data._normalize_text(license_text))
+            similarity = dice_coefficient(input_bigrams, license_bigrams)
+
+            if similarity >= CORROBORATION_THRESHOLD and (best is None or similarity > best[1]):
+                best = (license_id, similarity)
+
+        return best
+
     def detect_license_tlsh(self, text: str, file_path: Path) -> Optional[DetectedLicense]:
         """
         Detect license using TLSH fuzzy hashing.
-        
+
+        TLSH is used as a candidate generator, not as the verdict: the near
+        neighbours it proposes are re-checked against their actual license
+        texts, and only a corroborated candidate is reported. The reported
+        confidence is that text agreement, so a fuzzy match no longer outranks
+        an exact or keyword identification of the same file.
+
         Args:
             text: License text to analyze
             file_path: Source file path
-            
+
         Returns:
             DetectedLicense or None
         """
         if not TLSH_AVAILABLE:
             logger.debug("TLSH not available, skipping")
             return None
-        
+
         if not self._initialized:
             logger.debug("TLSH detector not initialized")
             return None
-        
+
         try:
             # Preprocess input text
             processed_text = self._preprocess_for_tlsh(text)
-            
+
             # Compute hash for input
             input_hash = tlsh.hash(processed_text.encode('utf-8'))
-            
+
             if not input_hash or input_hash == 'TNULL':
                 logger.debug("Could not compute TLSH hash for input text")
                 return None
-            
-            # Find best match
-            best_match = None
-            best_score = float('inf')
-            
-            for license_id, hash_data in self.license_hashes.items():
-                license_hash = hash_data['hash']
-                
-                # Calculate TLSH distance (lower is better)
-                try:
-                    distance = tlsh.diff(input_hash, license_hash)
-                    
-                    # TLSH distance of 0-30 is very similar
-                    # 30-100 is similar
-                    # 100+ is different
-                    if distance < best_score:
-                        best_score = distance
-                        best_match = license_id
-                
-                except Exception as e:
-                    logger.debug(f"Error comparing TLSH hashes: {e}")
-            
-            if best_match and best_score <= 30:  # Very similar threshold
-                # Convert TLSH distance to confidence score
-                # Distance 0 = 100% confidence
-                # Distance 30 = 97% confidence (our threshold)
-                confidence = max(0.97, 1.0 - (best_score / 1000))
-                
-                license_info = self.spdx_data.get_license_info(best_match)
-                
-                # Determine category based on filename
-                name_lower = file_path.name.lower()
-                is_license_file = any(pattern in name_lower for pattern in 
-                                     ['license', 'licence', 'copying', 'copyright', 'notice'])
-                category = LicenseCategory.DECLARED.value if is_license_file else LicenseCategory.DETECTED.value
-                
-                return DetectedLicense(
-                    spdx_id=best_match,
-                    name=license_info.get('name', best_match) if license_info else best_match,
-                    confidence=confidence,
-                    detection_method=DetectionMethod.TLSH.value,
-                    source_file=str(file_path),
-                    category=category,
-                    match_type="text_similarity"
+
+            candidates = self._find_near_neighbours(input_hash)
+            if not candidates:
+                return None
+
+            corroborated = self._corroborate(text, candidates)
+            if not corroborated:
+                logger.debug(
+                    f"TLSH proposed {candidates[0][1]} for {file_path} "
+                    f"(distance {candidates[0][0]}) but no candidate text corroborates it; "
+                    f"not asserting a license"
                 )
-            
-            return None
-        
+                return None
+
+            best_match, confidence = corroborated
+            license_info = self.spdx_data.get_license_info(best_match)
+
+            # Determine category based on filename
+            name_lower = file_path.name.lower()
+            is_license_file = any(pattern in name_lower for pattern in
+                                 ['license', 'licence', 'copying', 'copyright', 'notice'])
+            category = LicenseCategory.DECLARED.value if is_license_file else LicenseCategory.DETECTED.value
+
+            return DetectedLicense(
+                spdx_id=best_match,
+                name=license_info.get('name', best_match) if license_info else best_match,
+                confidence=confidence,
+                detection_method=DetectionMethod.TLSH.value,
+                source_file=str(file_path),
+                category=category,
+                match_type="text_similarity"
+            )
+
         except Exception as e:
             logger.error(f"Error in TLSH detection: {e}")
             return None
-    
+
     def confirm_license_match(self, text: str, license_id: str, threshold: int = 100) -> bool:
         """
         Confirm a license match using TLSH.

--- a/osslili/utils/text_similarity.py
+++ b/osslili/utils/text_similarity.py
@@ -1,0 +1,17 @@
+"""Text similarity helpers shared by the license detection tiers."""
+
+from typing import Set
+
+
+def create_bigrams(text: str) -> Set[str]:
+    """Create character bigrams from text."""
+    return {text[i:i + 2] for i in range(len(text) - 1)}
+
+
+def dice_coefficient(set1: Set[str], set2: Set[str]) -> float:
+    """Calculate the Dice-Sørensen coefficient between two sets."""
+    if not set1 or not set2:
+        return 0.0
+
+    intersection = len(set1 & set2)
+    return (2.0 * intersection) / (len(set1) + len(set2))

--- a/tests/test_matcher_accuracy.py
+++ b/tests/test_matcher_accuracy.py
@@ -1,0 +1,324 @@
+"""Matcher accuracy regression tests for issues #90 and #91.
+
+Both issues share a failure shape: a matcher asserted a license the scanned
+text does not carry, and did so at a confidence that outranked the matcher
+that had it right.
+
+1. Issue #91 — the keyword matcher read license *discussion* as a grant. The
+   PSF license stack describes at length how Python relates to the GPL while
+   being distributed under Python-2.0, and a keyword hit on that prose asserted
+   ``GPL-2.0-or-later``: copyleft claimed over a permissive package.
+
+2. Issue #90 — the TLSH matcher reported the nearest fuzzy-hash neighbour as
+   the declared license. TLSH measures bulk document similarity, so licenses
+   that differ by one clause are indistinguishable to it: canonical MIT text
+   sits closer to the JSON license than to MIT. Those clauses are exactly what
+   changes the obligations.
+"""
+
+import pytest
+
+from osslili.core.models import Config
+from osslili.detectors.license_detector import LicenseDetector
+
+
+# The Python license stack as shipped by CPython and typing_extensions: a
+# history section, GPL-compatibility footnotes, the PSF agreement, and the CNRI
+# clause that mentions material "previously distributed under the GNU General
+# Public License". Every GPL mention here is commentary; the grant is PSF's.
+PSF_LICENSE_STACK = """A. HISTORY OF THE SOFTWARE
+==========================
+
+Python was created in the early 1990s by Guido van Rossum at Stichting
+Mathematisch Centrum (CWI) in the Netherlands as a successor of a language
+called ABC.
+
+All Python releases are Open Source (see https://opensource.org for the Open
+Source Definition).  Historically, most, but not all, Python releases have
+also been GPL-compatible; the table below summarizes the various releases.
+
+Footnotes:
+
+(1) GPL-compatible doesn't mean that we're distributing Python under
+    the GPL.  All Python licenses, unlike the GPL, let you distribute
+    a modified version without making your changes open source.  The
+    GPL-compatible licenses make it possible to combine Python with
+    other software that is released under the GPL; the others don't.
+
+(2) According to Richard Stallman, 1.6.1 is not GPL-compatible, because
+    its license has a choice of law clause.
+
+B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
+===============================================================
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software in source or binary form and its
+associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use this software alone or in any derivative version.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.
+
+ACCEPT
+------
+
+CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
+---------------------------------------
+
+7. This License Agreement shall be governed by the federal intellectual
+property law of the United States.  Notwithstanding the foregoing, with
+regard to derivative works based on Python 1.6.1 that incorporate
+non-separable material that was previously distributed under the GNU
+General Public License (GPL), the law of the Commonwealth of Virginia
+shall govern this License Agreement.
+"""
+
+# Canonical MIT text, as a package ships it. The JSON license is this text plus
+# "The Software shall be used for Good, not Evil." — one sentence apart, and
+# the pair TLSH could not separate.
+MIT_CANONICAL = """MIT License
+
+Copyright (c) 2008-2020 Andrey Petrov and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+# Canonical BSD-3-Clause, as Flask and Click ship it. BSD-4-Clause is this text
+# plus the advertising clause; BSD-3-Clause-HP is a near-identical variant.
+BSD_3_CLAUSE_CANONICAL = """Copyright 2014 Pallets
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+3.  Neither the name of the copyright holder nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+"""
+
+
+@pytest.fixture(scope="module")
+def detector():
+    det = LicenseDetector(Config())
+    _ = det.spdx_data.licenses
+    return det
+
+
+def _detect(detector, tmp_path, filename, text):
+    license_file = tmp_path / filename
+    license_file.write_text(text)
+    return detector.detect_licenses(license_file)
+
+
+def _ids(detector, tmp_path, filename, text):
+    return sorted({d.spdx_id for d in _detect(detector, tmp_path, filename, text)})
+
+
+class TestKeywordDiscussionProse:
+    """Issue #91: a license discussed is not a license granted."""
+
+    def test_psf_stack_does_not_assert_gpl(self, detector, tmp_path):
+        """The PSF stack's GPL commentary must not yield a GPL identifier."""
+        ids = _ids(detector, tmp_path, "LICENSE", PSF_LICENSE_STACK)
+        gpl_ids = [i for i in ids if "GPL" in i.upper()]
+        assert not gpl_ids, (
+            f"asserted {gpl_ids} from a package licensed under the PSF stack; "
+            f"every GPL mention in that text is compatibility or history prose"
+        )
+
+    def test_psf_stack_is_recognised(self, detector, tmp_path):
+        """Suppressing the GPL false positive must not silence the real answer."""
+        ids = _ids(detector, tmp_path, "LICENSE", PSF_LICENSE_STACK)
+        assert "Python-2.0" in ids, f"PSF stack classified as {ids}"
+
+    @pytest.mark.parametrize("prose", [
+        "This library is GPL-compatible, but is distributed under the MIT license.",
+        "Unlike the GPL, this license does not require you to publish changes.",
+        "Material previously distributed under the GNU General Public License "
+        "has been removed.",
+    ])
+    def test_discussion_prose_yields_no_gpl(self, detector, tmp_path, prose):
+        ids = _ids(detector, tmp_path, "NOTICE", prose)
+        assert not [i for i in ids if "GPL" in i.upper()], (
+            f"asserted a GPL identifier from discussion prose: {prose!r} -> {ids}"
+        )
+
+    def test_linking_exception_does_not_assert_the_carved_out_license(
+        self, detector, tmp_path
+    ):
+        """A linking exception names a library to carve it out, not to adopt it.
+
+        The GPL "special exception" boilerplate names the library it permits
+        linking against; that library's license does not govern the file.
+        """
+        text = (
+            "In addition, as a special exception, Nokia gives permission to link\n"
+            "the code of its release of Qt with the OpenSSL project's \"OpenSSL\"\n"
+            "library (or modified versions of it that use the same license as the\n"
+            "\"OpenSSL\" library), and distribute the linked executables.\n"
+        )
+        ids = _ids(detector, tmp_path, "LICENSE", text)
+        assert "OpenSSL" not in ids, (
+            f"asserted the OpenSSL license from a linking exception: {ids}"
+        )
+
+
+class TestUnversionedGnuMention:
+    """Issue #91: an unversioned GPL mention names a family, not a license.
+
+    GPL-2.0-only and GPL-3.0-only are mutually incompatible, so resolving a
+    bare "General Public License" to either one invents an obligation.
+    """
+
+    def test_unversioned_mention_yields_no_identifier(self, detector, tmp_path):
+        text = "This program is distributed under the terms of the General Public License.\n"
+        ids = _ids(detector, tmp_path, "COPYING", text)
+        assert not [i for i in ids if "GPL" in i.upper()], (
+            f"guessed {ids} from a mention that names no version"
+        )
+
+    @pytest.mark.parametrize("text,expected", [
+        ("This program is distributed under the terms of the GNU GPL version 2.\n",
+         "GPL-2.0"),
+        ("This program is distributed under the terms of the GNU GPL version 3.\n",
+         "GPL-3.0"),
+        ("Licensed under the GNU General Public License v3.\n", "GPL-3.0"),
+    ])
+    def test_versioned_mention_resolves_to_that_version(
+        self, detector, tmp_path, text, expected
+    ):
+        ids = _ids(detector, tmp_path, "COPYING", text)
+        # Emitted in modern SPDX form, so the bare id appears with a suffix.
+        assert any(i.startswith(expected) for i in ids), (
+            f"{text!r} classified as {ids}, expected a {expected} identifier"
+        )
+
+    def test_a_year_is_not_a_version(self, detector, tmp_path):
+        """The old version sniffer accepted any digit in a 200-character window."""
+        text = (
+            "Copyright 2003 Example Corp.\n"
+            "Redistribution is governed by the General Public License referenced above.\n"
+        )
+        ids = _ids(detector, tmp_path, "NOTICE", text)
+        assert "GPL-3.0-only" not in ids and "GPL-3.0-or-later" not in ids, (
+            f"read the year 2003 as a GPL version: {ids}"
+        )
+
+
+class TestKeywordWordBoundaries:
+    """A short identifier must not match inside an ordinary word.
+
+    "MIT" occurs in "permitted" and "limitation", which run throughout the
+    LGPL and MPL texts.
+    """
+
+    @pytest.mark.parametrize("text", [
+        "Redistribution is permitted under the terms of this license.\n",
+        "Including without limitation the rights granted under this license.\n",
+    ])
+    def test_mit_inside_a_word_is_not_a_match(self, detector, tmp_path, text):
+        ids = _ids(detector, tmp_path, "NOTICE", text)
+        assert "MIT" not in ids, f"matched MIT inside a word: {text!r} -> {ids}"
+
+    def test_real_mit_mention_still_matches(self, detector, tmp_path):
+        keywords = detector._detect_license_keywords(
+            "This project is distributed under the MIT License.\n",
+            tmp_path / "README.md",
+        )
+        assert "MIT" in {k.spdx_id for k in keywords}
+
+
+class TestTlshCorroboration:
+    """Issue #90: TLSH proposes candidates; it does not get to decide."""
+
+    NEAR_NEIGHBOUR_CASES = [
+        ("LICENSE.txt", MIT_CANONICAL, "MIT", "JSON"),
+        ("LICENSE.txt", BSD_3_CLAUSE_CANONICAL, "BSD-3-Clause", "BSD-4-Clause"),
+    ]
+
+    @pytest.mark.parametrize(
+        "filename,text,actual,near_neighbour", NEAR_NEIGHBOUR_CASES
+    )
+    def test_near_neighbour_is_not_asserted(
+        self, detector, tmp_path, filename, text, actual, near_neighbour
+    ):
+        """The neighbour a clause away must never be reported for this text."""
+        result = detector.tlsh_detector.detect_license_tlsh(text, tmp_path / filename)
+        assert result is None or result.spdx_id != near_neighbour, (
+            f"TLSH reported {near_neighbour} for {actual} text"
+        )
+
+    @pytest.mark.parametrize(
+        "filename,text,actual,near_neighbour", NEAR_NEIGHBOUR_CASES
+    )
+    def test_pipeline_reports_the_actual_license(
+        self, detector, tmp_path, filename, text, actual, near_neighbour
+    ):
+        ids = _ids(detector, tmp_path, filename, text)
+        assert ids == [actual], f"{actual} text classified as {ids}"
+
+    def test_uncorroborated_candidate_is_not_asserted(self, detector, tmp_path):
+        """A proposal whose license text is unavailable cannot be checked.
+
+        Only a minority of the bundled SPDX entries carry their text, so most
+        TLSH proposals cannot be substantiated. Silence beats a guess.
+        """
+        tlsh_detector = detector.tlsh_detector
+        candidates = [(3, "JSON")]  # JSON ships no text in the bundled data
+        assert tlsh_detector.spdx_data.get_license_text("JSON") is None
+        assert tlsh_detector._corroborate(MIT_CANONICAL, candidates) is None
+
+    def test_corroborated_candidate_reports_text_agreement(self, detector, tmp_path):
+        """Confidence is the measured agreement, not a fixed floor."""
+        corroborated = detector.tlsh_detector._corroborate(
+            MIT_CANONICAL, [(29, "MIT")]
+        )
+        assert corroborated is not None, "MIT text should corroborate the MIT candidate"
+        license_id, similarity = corroborated
+        assert license_id == "MIT"
+        assert similarity >= 0.95, (
+            f"canonical MIT text agrees with the MIT license text at only {similarity}"
+        )


### PR DESCRIPTION
Fixes #90. Fixes #91.

Both issues share a failure shape: a matcher asserted a license the scanned text does not grant, at a confidence that outranked the matcher that had it right.

## Reproduction status against `main` (1.7.0)

The issues were filed against 1.6.1, and part of what they report has already been fixed:

| Reported | Status on `main` |
|---|---|
| #91 `Apache-2.0-only` emitted for Apache-2.0 text | Already fixed by #65 (1.6.3); not reproducible |
| #91 `GPL-2.0-or-later` from the PSF stack | Reproduces |
| #90 TLSH near-neighbour cases | Not visible through the pipeline, but the matcher is still wrong — see below |

The #90 cases stopped showing up because #77's normalizer fix let the Dice-Sørensen tier answer first. Called directly, the TLSH matcher on `main` still returns `JSON` for MIT and `BSD-4-Clause` for BSD-3-Clause. It was shadowed, not fixed: any text whose Dice score lands under `similarity_threshold` still reaches it.

## #90 — TLSH cannot discriminate near-identical licenses

Not a threshold-tuning problem. For canonical MIT text, TLSH puts **JSON at distance 17 and MIT at 29** — the wrong answer is genuinely closer. TLSH measures bulk document similarity, and JSON is MIT plus one sentence, which offsets the length of a package's own copyright line. Those clauses are what change the obligations.

Compounding it: only **46 of the 703** bundled SPDX entries carry their license text, so most TLSH proposals could not be cross-checked against anything.

TLSH is now a candidate generator rather than the verdict:

- every near neighbour within the distance threshold is collected, not just the argmax
- a candidate is asserted only once its own license text corroborates the scanned text (Dice-Sørensen ≥ 0.9)
- a proposal that cannot be substantiated is dropped, leaving the answer to the tiers that can back it up
- confidence is the measured text agreement instead of a floor of exactly 0.97 — that floor is what let a fuzzy guess outrank the keyword matcher's correct answer at 0.85–0.9, and it also made the tier-2 gate a no-op

## #91 — a license discussed is not a license granted

The culprit in the PSF stack is the CNRI clause: *"material that was previously distributed under the GNU General Public License (GPL)"*.

- mentions framed as compatibility notes, license history, exclusions, or linking exceptions no longer count as a grant, scoped to the containing paragraph
- all occurrences of a keyword are examined rather than only the first, so rejecting a mention means "keep looking" instead of giving up on the file
- an unversioned "GPL" / "General Public License" mention yields no identifier: it names a family, and `GPL-2.0-only` and `GPL-3.0-only` are mutually incompatible, so resolving it to either invents an obligation. The previous fallback guessed `GPL-2.0-or-later`, and its version sniffer accepted any digit in the surrounding window — a copyright year could read as a version

Walking every occurrence exposed a latent bug: `MIT` matched inside "per**mit**ted" and "li**mit**ation", which run throughout the LGPL and MPL texts. Keyword variations now match on word boundaries, added only on sides ending in a word character so variations bounded by punctuation (`MIT/X11`) still match.

## Verification

Swept all 69 license files in a populated `site-packages`, before vs after. Four results change, all improvements:

| Package | Declared | Change |
|---|---|---|
| aiohappyeyeballs | PSF-2.0 | spurious `GPL-2.0-or-later` gone |
| pandas | BSD-3-Clause | spurious `GPL-2.0-or-later` gone |
| dill | BSD-3-Clause | TLSH `BSD-3-Clause-Attribution` → `BSD-3-Clause` |
| matplotlib | aggregate | `CC0-1.0` added, agreeing with an existing tag match |

Canonical GPL-2/3, LGPL-2.1/3, AGPL-3, MPL-2, Apache-2.0, MIT and BSD-3 texts all resolve unchanged.

`tests/test_matcher_accuracy.py` adds 20 tests; 7 of them fail on the pre-fix code and pass after. Suite: 127 passing (107 existing + 20 new).

## Known limitation

The 46/703 license-text coverage is the underlying weakness behind #90. Corroboration now fails safe, but the fuzzy tier can only ever confirm within those 46 licenses. Widening it is a data change (bundling more SPDX texts), so it is out of scope here.
