### PR TITLE
Release 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to osslili will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.7.1] - 2026-08-11
 
 ### Fixed
 - **TLSH matcher reported near-identical licenses as declared** (Issue #90): the matcher returned its nearest fuzzy-hash neighbour as the verdict at a confidence floored at 0.97, which outranked the matchers that had the file right. TLSH measures bulk document similarity, so licenses that differ by a single clause are indistinguishable to it — canonical MIT text sits closer to the JSON license (distance 17) than to MIT itself (29), and those clauses are exactly what changes the obligations

--- a/osslili/__init__.py
+++ b/osslili/__init__.py
@@ -13,7 +13,7 @@ if os.environ.get('OSLILI_DEBUG') != '1':
     except ImportError:
         pass
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 
 from .core.generator import LicenseCopyrightDetector
 from .core.models import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "osslili"
-version = "1.7.0"
+version = "1.7.1"
 description = "Open Source License Identification Library"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumps the version to 1.7.1 and dates the changelog entry for the matcher accuracy fixes.

Patch release: both changes are bug fixes to license detection, matching how 1.6.4 and 1.6.5 shipped detection-accuracy work.

## Contents

- **#90** — the TLSH matcher reported its nearest fuzzy-hash neighbour as `declared` at a confidence floored at 0.97, outranking the matchers that had the file right. TLSH is now a candidate generator: a proposal is asserted only once the license's own text corroborates it, and confidence is the measured agreement.
- **#91** — the keyword matcher read license discussion as a grant, asserting `GPL-2.0-or-later` over the permissive PSF license stack. Compatibility notes, history, exclusions, and linking exceptions no longer count as grants; an unversioned GPL mention yields no identifier; keyword variations match on word boundaries.

Both merged in #92.

Once merged, publishing the `v1.7.1` GitHub release triggers the PyPI upload.