### PR TITLE
Restore licenses that 1.7.1 stopped detecting

### DIFF
--- a/osslili/detectors/license_detector.py
+++ b/osslili/detectors/license_detector.py
@@ -38,31 +38,80 @@ _DEPRECATED_GNU_RE = re.compile(r'^(?:A?GPL|LGPL|GFDL)-\d+(?:\.\d+)?$')
 # while the package itself is Python-2.0, and a keyword hit on that prose used
 # to assert copyleft over a permissive package (issue #91).
 _LICENSE_DISCUSSION_RE = re.compile(
-    r'compatib'                                                   # GPL-compatible, compatibility
-    r'|incompatib'
+    # A compatibility *claim about licensing*, not the ordinary English word.
+    # "ensuring compatibility with both open source and commercial products"
+    # sits in a genuine grant sentence and must not suppress it.
+    r'(?:licen[sc]e|GPL|LGPL|AGPL|BSD|MIT|Apache|MPL)[\s-]*(?:in)?compatib'
+    r'|(?:in)?compatib\w*\s+with\s+(?:the\s+)?(?:GNU\s+)?'
+    r'(?:GPL|LGPL|AGPL|BSD|MIT|Apache|MPL|General\s+Public|licen[sc]e)'
     r'|unlike\s+th(?:e|is)\b'
     r'|(?:previously|formerly|originally)\s+(?:distributed|released|licen[sc]ed)'
     r'|does\s+not\s+mean\b'
-    r'|(?:is|are|was|were)\s+not\s+(?:distributed|released|licen[sc]ed)\b'
-    r'|as\s+a\s+special\s+exception'                              # linking exceptions
+    r'|(?:is|are|was|were)\s+not\s+(?:distributed|released|licen[sc]ed)\b',
+    re.IGNORECASE,
+)
+
+# Linking exceptions get their own guard. They name a library's license only to
+# carve it out — "permission to link ... with the OpenSSL library" — so the
+# named license does not govern the file. But the exception is *attached to* a
+# copyleft grant, and the file carrying it is by definition licensed under that
+# copyleft license. Suppressing the GNU-family match too reported GPL source
+# files as carrying no license at all, so this guard never applies to them.
+_LINKING_EXCEPTION_RE = re.compile(
+    r'as\s+a\s+special\s+exception'
     r'|permission\s+to\s+link'
     r'|linking\s+exception',
     re.IGNORECASE,
 )
 
+# License families a linking exception is granted *over*, never carved out of.
+_GNU_FAMILY_PREFIXES = ('GPL', 'LGPL', 'AGPL', 'GFDL')
+
 # Cap on how far the discussion scan reaches from a match when the text has no
 # paragraph breaks to bound it.
 _DISCUSSION_SPAN_LIMIT = 400
 
-# An explicit GNU version, as it is actually written: "v2", "version 3",
-# "GPL-2.0", "GPLv3". A bare digit anywhere nearby is not a version — a
-# copyright year or a section number would do just as well — so an unversioned
-# mention yields no identifier at all rather than a guessed one.
+# A paragraph break: a blank line, or a line carrying nothing but comment
+# markers. Source headers are the reason for the second case — in a "/* ... */"
+# block the blank lines read as " *", so searching for "\n\n" alone finds no
+# break at all and runs the entire header together as one paragraph.
+_PARAGRAPH_BREAK_RE = re.compile(r'\n[ \t]*(?:[*#]|//|--|;)?[ \t]*\r?\n')
+
+# An explicit GNU version, as licenses actually write it. Covers the phrasing
+# the FSF itself recommends and which most GPL source headers therefore use --
+# "either version 2 of the License, or (at your option) any later version" --
+# where the version attaches to "the License" rather than to "GPL". Also covers
+# "GPL-2.0", "GPLv3", "GPL version 2", and the separator-less "GPL2".
+#
+# A bare digit near a license name is still not a version: a copyright year or a
+# section number would qualify just as well, so an unversioned mention yields no
+# identifier rather than a guessed one.
 _GNU_VERSION_RE = re.compile(
-    r'(?:GPL|General\s+Public\s+License)[\s,-]*v?(?:ersion\s*)?([123])(?:\.\d+)?\b'
-    r'|\bv(?:ersion\s*)?([123])(?:\.\d+)?\s*(?:of\s+the\s+)?(?:GNU\s+)?(?:GPL|General\s+Public\s+License)',
+    r'(?:A?GPL|LGPL|General\s+Public\s+License)[\s,-]*v?(?:ersion\s*)?([123])(?:\.\d+)?\b'
+    r'|\bv(?:ersion\s*)?\s*([123])(?:\.\d+)?\s+of\s+the\s+(?:GNU\s+)?'
+    r'(?:A?GPL|LGPL|General\s+Public\s+)?Licen[sc]e\b'
+    r'|\bv(?:ersion\s*)?([123])(?:\.\d+)?\s*(?:of\s+the\s+)?(?:GNU\s+)?'
+    r'(?:A?GPL|LGPL|General\s+Public\s+License)',
     re.IGNORECASE,
 )
+
+# "or (at your option) any later version" — the FSF header wording that makes a
+# versioned grant an "-or-later" one rather than "-only".
+_GNU_OR_LATER_RE = re.compile(
+    r'any\s+later\s+version|or\s+later\b|or,?\s+at\s+your\s+option',
+    re.IGNORECASE,
+)
+
+# A generic "General Public License" match that is really part of the Lesser or
+# Affero name. Those have their own identifiers, so the generic GPL path must
+# not claim them.
+_GNU_VARIANT_PREFIX_RE = re.compile(r'(?:Lesser|Library|Affero)\s+$', re.IGNORECASE)
+
+# Ceiling on a regex match reached through the full-text cascade, i.e. after
+# every tier that compares actual text has declined. Set below the keyword tier
+# so a pattern hit on an unrecognized document cannot outrank a license name
+# read in context, let alone a real text match.
+_UNIDENTIFIED_TEXT_CONFIDENCE_CAP = 0.6
 
 # The number of occurrences of a single keyword variation examined per file.
 # Bounds the cost on pathological inputs while leaving room to skip over
@@ -80,11 +129,15 @@ def _paragraph_around(content: str, start: int, end: int) -> str:
     reaches too short to catch the exception or far enough to swallow the
     heading in a densely packed aggregate license file.
     """
-    paragraph_start = content.rfind('\n\n', 0, start)
-    paragraph_start = 0 if paragraph_start == -1 else paragraph_start + 2
+    # Inside a block comment a "blank" line still carries its comment marker
+    # (" *", "#", "//"), so a bare "\n\n" search runs the whole file together.
+    # Treat a line with nothing but markers and whitespace as a break too.
+    paragraph_start = 0
+    for match in _PARAGRAPH_BREAK_RE.finditer(content, 0, start):
+        paragraph_start = match.end()
 
-    paragraph_end = content.find('\n\n', end)
-    paragraph_end = len(content) if paragraph_end == -1 else paragraph_end
+    paragraph_end_match = _PARAGRAPH_BREAK_RE.search(content, end)
+    paragraph_end = paragraph_end_match.start() if paragraph_end_match else len(content)
 
     return content[
         max(paragraph_start, start - _DISCUSSION_SPAN_LIMIT):
@@ -1507,9 +1560,9 @@ class LicenseDetector:
         # Base license families with common variations
         base_license_mapping = {
             # GPL family
-            'GPL-3.0': ['GPL-3', 'GPLv3', 'GPL version 3', 'GNU General Public License v3',
+            'GPL-3.0': ['GPL-3', 'GPL3', 'GPLv3', 'GPL version 3', 'GNU General Public License v3',
                         'GNU General Public License version 3', 'GPL v3'],
-            'GPL-2.0': ['GPL-2', 'GPLv2', 'GPL version 2', 'GNU General Public License v2',
+            'GPL-2.0': ['GPL-2', 'GPL2', 'GPLv2', 'GPL version 2', 'GNU General Public License v2',
                         'GNU General Public License version 2', 'GPL v2', 'GNU GPL v2',
                         'terms-of-the-GNU-GPL', 'GNU-GPL-v2'],  # Add normalization patterns
             'GPL': ['GPL', 'the GPL', 'GNU GPL', 'General Public License'],  # Generic GPL
@@ -1713,6 +1766,17 @@ class LicenseDetector:
                         )
                         continue
 
+                    # A linking exception carves out the library it names, but is
+                    # itself granted over a copyleft license — so it never
+                    # disqualifies a GNU-family match in the same paragraph.
+                    if (not spdx_id.startswith(_GNU_FAMILY_PREFIXES)
+                            and _LINKING_EXCEPTION_RE.search(paragraph)):
+                        logger.debug(
+                            f"Skipping '{variation}' in {file_path}: named by a "
+                            f"linking exception, not granted"
+                        )
+                        continue
+
                     has_context = any(re.search(pattern, context, re.IGNORECASE) for pattern in context_patterns)
 
                     # Check for comment or line start (more strict)
@@ -1751,7 +1815,17 @@ class LicenseDetector:
                     # GPL-3.0-only are mutually incompatible, so guessing one
                     # invents an obligation. Report nothing instead.
                     if final_spdx_id == 'GPL':
-                        context_text = content[max(0, match.start()-100):min(len(content), match.end()+100)]
+                        # "Lesser"/"Affero General Public License" have their own
+                        # identifiers; the generic path must not claim them.
+                        preceding = content[max(0, match.start() - 16):match.start()]
+                        if _GNU_VARIANT_PREFIX_RE.search(preceding):
+                            continue
+
+                        # Wide enough to reach the version in the FSF header,
+                        # where it trails the license name by a clause.
+                        context_text = content[
+                            max(0, match.start() - 120):min(len(content), match.end() + 180)
+                        ]
                         version_match = _GNU_VERSION_RE.search(context_text)
                         if not version_match:
                             logger.debug(
@@ -1759,8 +1833,13 @@ class LicenseDetector:
                                 f"no explicit version to resolve it to"
                             )
                             continue
-                        version = version_match.group(1) or version_match.group(2)
+                        version = next(g for g in version_match.groups() if g)
                         final_spdx_id = f'GPL-{version}.0'
+
+                        # "or (at your option) any later version" makes the grant
+                        # an -or-later one; without it the version stands alone.
+                        if _GNU_OR_LATER_RE.search(context_text):
+                            final_spdx_id += '-or-later'
 
                     licenses.append(DetectedLicense(
                         spdx_id=final_spdx_id,
@@ -2066,9 +2145,24 @@ class LicenseDetector:
         if detected:
             return detected
         
-        # Tier 3: Regex pattern matching
+        # Tier 3: Regex pattern matching. Reaching here means every tier that
+        # actually compares text declined to identify this one, so a pattern hit
+        # is a weak signal about an unrecognized document — not the confident
+        # identification that a license file would otherwise be scored at.
+        #
+        # Left unbounded, this asserted the wrong license at full confidence for
+        # any license whose text is not bundled: a Sleepycat file, which no tier
+        # could match, was reported as BSD-3-Clause at 1.0 because the patterns
+        # for the BSD clauses it shares fired. Copyleft reported as permissive,
+        # with nothing in the output to suggest doubt.
         detected = self._tier3_regex_matching(text, file_path)
         if detected:
+            if detected.confidence > _UNIDENTIFIED_TEXT_CONFIDENCE_CAP:
+                logger.debug(
+                    f"Capping regex confidence for {detected.spdx_id} in {file_path}: "
+                    f"no text tier could identify this document"
+                )
+                detected.confidence = _UNIDENTIFIED_TEXT_CONFIDENCE_CAP
             return detected
         
         # No match found

--- a/osslili/detectors/tlsh_detector.py
+++ b/osslili/detectors/tlsh_detector.py
@@ -26,6 +26,25 @@ NEAR_NEIGHBOUR_DISTANCE = 30
 # the Dice-Sørensen tier applies to its own matches.
 CORROBORATION_THRESHOLD = 0.9
 
+# How far the runner-up must sit behind the best candidate for that candidate to
+# count as unambiguous. TLSH's weakness is discriminating between licenses that
+# differ by a clause; when nothing else is anywhere near, that weakness does not
+# apply and the match can be trusted without a text to check it against.
+#
+# Measured, not guessed. Across the near-neighbour confusions from issue #90 the
+# wrong answer never led by more than 13 (MIT->JSON 12, ->JSON 13,
+# BSD-3->BSD-4 3 and 2, BSD-3->BSD-3-Clause-HP 1). Across licenses TLSH gets
+# right but cannot corroborate, the correct answer leads by 20 or more
+# (Sleepycat 43, Python-2.0 39, Apache-1.1 26, CECILL-2.1 20). Nothing falls
+# between, so 20 separates them cleanly.
+UNAMBIGUOUS_MARGIN = 20
+
+# Confidence band for an unambiguous but uncorroborated match, interpolated over
+# the distance threshold. Deliberately below the exact-hash and Dice-Sørensen
+# tiers: this is a whole-document resemblance, not a text identification.
+_UNCORROBORATED_CONFIDENCE_MAX = 0.95
+_UNCORROBORATED_CONFIDENCE_MIN = 0.75
+
 # Try to import tlsh, make it optional
 try:
     import tlsh
@@ -212,6 +231,49 @@ class TLSHDetector:
 
         return best
 
+    def _unambiguous_match(self, input_hash: str, candidates: list) -> Optional[tuple]:
+        """
+        Accept the best candidate only when nothing else is close to it.
+
+        The confusions TLSH is prone to all look the same: a cluster of licenses
+        that differ by a clause, sitting within a few points of each other. A
+        best candidate that leads the whole license list by a wide margin is not
+        that situation, and is reliable even with no text to check it against.
+
+        The runner-up is taken from the entire hash table, not just the near
+        neighbour list, so a second candidate sitting just outside the near
+        neighbour threshold still counts against the match.
+
+        Args:
+            input_hash: TLSH hash of the preprocessed scanned text
+            candidates: (distance, license_id) tuples, closest first
+
+        Returns:
+            (license_id, confidence) when unambiguous, otherwise None
+        """
+        best_distance, best_match = candidates[0]
+
+        runner_up = None
+        for license_id, hash_data in self.license_hashes.items():
+            if license_id == best_match:
+                continue
+            try:
+                distance = tlsh.diff(input_hash, hash_data['hash'])
+            except Exception:
+                continue
+            if runner_up is None or distance < runner_up:
+                runner_up = distance
+
+        if runner_up is not None and runner_up - best_distance < UNAMBIGUOUS_MARGIN:
+            return None
+
+        # Closer match, higher confidence, held below the text-matching tiers.
+        span = _UNCORROBORATED_CONFIDENCE_MAX - _UNCORROBORATED_CONFIDENCE_MIN
+        confidence = _UNCORROBORATED_CONFIDENCE_MAX - (
+            best_distance / NEAR_NEIGHBOUR_DISTANCE
+        ) * span
+        return best_match, round(confidence, 3)
+
     def detect_license_tlsh(self, text: str, file_path: Path) -> Optional[DetectedLicense]:
         """
         Detect license using TLSH fuzzy hashing.
@@ -252,16 +314,25 @@ class TLSHDetector:
             if not candidates:
                 return None
 
+            # Preferred: the candidate's own license text confirms the match.
             corroborated = self._corroborate(text, candidates)
-            if not corroborated:
-                logger.debug(
-                    f"TLSH proposed {candidates[0][1]} for {file_path} "
-                    f"(distance {candidates[0][0]}) but no candidate text corroborates it; "
-                    f"not asserting a license"
-                )
-                return None
-
-            best_match, confidence = corroborated
+            if corroborated:
+                best_match, confidence = corroborated
+            else:
+                # Only a minority of SPDX entries ship their text, so most
+                # candidates can never be corroborated. Falling silent for all of
+                # them loses licenses TLSH identifies perfectly well and hands the
+                # verdict to weaker tiers, so an unambiguous match is still
+                # asserted — see UNAMBIGUOUS_MARGIN.
+                unambiguous = self._unambiguous_match(input_hash, candidates)
+                if not unambiguous:
+                    logger.debug(
+                        f"TLSH proposed {candidates[0][1]} for {file_path} "
+                        f"(distance {candidates[0][0]}) but it is neither corroborated "
+                        f"by a license text nor unambiguous; not asserting a license"
+                    )
+                    return None
+                best_match, confidence = unambiguous
             license_info = self.spdx_data.get_license_info(best_match)
 
             # Determine category based on filename

--- a/tests/test_false_negatives.py
+++ b/tests/test_false_negatives.py
@@ -1,0 +1,234 @@
+"""Regression tests for the false negatives introduced in 1.7.1.
+
+1.7.1 fixed a class of false positives (issues #90 and #91) and, in doing so,
+created a larger class of false negatives. Its own tests could not see them:
+they asserted that licenses which *should* resolve still did, which cannot
+detect a license that stopped resolving, and every fixture was a full LICENSE
+file drawn from the minority of SPDX entries that ship their text — exactly the
+population where the new failures do not occur.
+
+These tests cover what that corpus could not:
+
+* source-file license headers, not just LICENSE files
+* licenses whose text is *not* bundled, so the fuzzy tier cannot corroborate
+* the direction that matters most for compliance — a license that used to be
+  identified and now is not, or copyleft reported as permissive
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from osslili.core.models import Config
+from osslili.detectors.license_detector import LicenseDetector
+
+
+# The header the FSF itself recommends, and therefore the most widely used
+# license header in existence. The version attaches to "the License", not to
+# "GPL", which is what the 1.7.1 version regex failed to parse.
+FSF_GPL2_HEADER = """/*
+ * demo.c - part of the demo project
+ *
+ * Copyright (C) 2024 Example Corp
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+int main(void) { return 0; }
+"""
+
+FSF_GPL3_HEADER = FSF_GPL2_HEADER.replace(
+    "version 2 of the License", "version 3 of the License"
+)
+
+# A GPL grant carrying a linking exception. Files like this are, by definition,
+# GPL-licensed — the exception is granted *over* the GPL, not instead of it.
+GPL_WITH_LINKING_EXCEPTION = """/*
+ * Copyright (C) 2024 Example Corp
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of this program with the OpenSSL library.
+ */
+int main(void) { return 0; }
+"""
+
+# "compatibility" as an ordinary English word inside a real grant sentence.
+ZLIB_GRANT_MENTIONING_COMPATIBILITY = (
+    "minizip is distributed under the zlib license, ensuring compatibility\n"
+    "with both open source and commercial products.\n"
+)
+
+LGPL_21_MENTION = (
+    "This library is distributed under the GNU Lesser General Public "
+    "License version 2.1.\n"
+)
+
+
+@pytest.fixture(scope="module")
+def detector():
+    det = LicenseDetector(Config())
+    _ = det.spdx_data.licenses
+    return det
+
+
+def _ids(detector, filename, text):
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td, filename)
+        path.write_text(text)
+        return {d.spdx_id for d in detector.detect_licenses(path)}
+
+
+def _detections(detector, filename, text):
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td, filename)
+        path.write_text(text)
+        return detector.detect_licenses(path)
+
+
+class TestSourceHeaderGrants:
+    """A license header in source must still be identified.
+
+    Requiring an explicit GNU version was right; the version regex was too
+    narrow to read the phrasing licenses actually use.
+    """
+
+    @pytest.mark.parametrize("label,text,expected", [
+        ("GPL-2 FSF header", FSF_GPL2_HEADER, "GPL-2.0"),
+        ("GPL-3 FSF header", FSF_GPL3_HEADER, "GPL-3.0"),
+    ])
+    def test_canonical_fsf_header_is_identified(self, detector, label, text, expected):
+        ids = _ids(detector, "demo.c", text)
+        assert any(i.startswith(expected) for i in ids), (
+            f"{label} reported {ids or 'nothing'}; a GPL source file must not "
+            f"read as carrying no license"
+        )
+
+    def test_any_later_version_resolves_to_or_later(self, detector):
+        """"or (at your option) any later version" is an -or-later grant."""
+        ids = _ids(detector, "demo.c", FSF_GPL2_HEADER)
+        assert "GPL-2.0-or-later" in ids, (
+            f"expected GPL-2.0-or-later for a header offering later versions, got {ids}"
+        )
+
+    def test_version_only_grant_is_not_reported_as_or_later(self, detector):
+        """Without the later-version clause the grant is version-specific."""
+        text = (
+            "/* This program is distributed under the terms of the GNU General\n"
+            " * Public License, version 2 of the License.\n"
+            " */\n"
+        )
+        ids = _ids(detector, "demo.c", text)
+        assert "GPL-2.0-or-later" not in ids, (
+            f"read an -or-later grant where the text offers only version 2: {ids}"
+        )
+
+    def test_informal_separatorless_mention(self, detector):
+        """"licensed under GPL2" is common in READMEs."""
+        ids = _ids(detector, "README.md", "This project is licensed under GPL2.\n")
+        assert any(i.startswith("GPL-2.0") for i in ids), f"got {ids}"
+
+
+class TestLinkingExceptionKeepsItsGrant:
+    """A linking exception carves out a library; it does not remove the grant."""
+
+    def test_gpl_grant_survives_its_own_linking_exception(self, detector):
+        ids = _ids(detector, "demo.c", GPL_WITH_LINKING_EXCEPTION)
+        assert any(i.startswith("GPL-3.0") for i in ids), (
+            f"a GPL file carrying a linking exception reported {ids or 'nothing'}"
+        )
+
+    def test_carved_out_library_is_still_not_asserted(self, detector):
+        """The reason the guard exists must keep working."""
+        ids = _ids(detector, "demo.c", GPL_WITH_LINKING_EXCEPTION)
+        assert "OpenSSL" not in ids, (
+            f"asserted the carved-out library's license: {ids}"
+        )
+
+
+class TestCompatibilityIsNotAlwaysDiscussion:
+    """"compatibility" is an ordinary word, not only a licensing claim."""
+
+    def test_grant_mentioning_compatibility_is_kept(self, detector):
+        ids = _ids(detector, "README.md", ZLIB_GRANT_MENTIONING_COMPATIBILITY)
+        assert "Zlib" in ids, (
+            f"a genuine zlib grant was suppressed by the word 'compatibility': {ids}"
+        )
+
+    def test_licensing_compatibility_claim_is_still_discussion(self, detector):
+        """The PSF-stack case that motivated the guard must stay suppressed."""
+        text = (
+            "Historically, most, but not all, Python releases have also been\n"
+            "GPL-compatible; the table below summarizes the various releases.\n"
+        )
+        ids = _ids(detector, "LICENSE", text)
+        assert not [i for i in ids if "GPL" in i.upper()], (
+            f"asserted a GPL identifier from a compatibility note: {ids}"
+        )
+
+
+class TestGnuVariantsAreNotClaimedAsGpl:
+    """Lesser and Affero have their own identifiers."""
+
+    def test_lgpl_mention_does_not_assert_plain_gpl(self, detector):
+        ids = _ids(detector, "README.md", LGPL_21_MENTION)
+        assert not [i for i in ids if i.startswith("GPL-")], (
+            f"claimed a plain GPL identifier for an LGPL mention: {ids}"
+        )
+        assert any(i.startswith("LGPL-2.1") for i in ids), f"got {ids}"
+
+
+class TestUnidentifiableTextIsNotConfident:
+    """A pattern hit on text no tier could identify is not a full-confidence
+    identification.
+
+    A Sleepycat license file was reported as BSD-3-Clause at 1.0 because the
+    BSD clauses it shares matched patterns — copyleft as permissive, with
+    nothing in the output to signal doubt.
+    """
+
+    UNKNOWN_LICENSE_TEXT = """Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in any form must be accompanied by information on how to
+   obtain complete source code for this software and any accompanying
+   software that uses this software.  The source code must either be
+   included in the distribution or be available for no more than the cost
+   of distribution plus a nominal fee, and must be freely redistributable
+   under reasonable conditions.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS "AS IS" AND ANY EXPRESS
+OR IMPLIED WARRANTIES ARE DISCLAIMED.
+"""
+
+    def test_regex_fallback_is_capped(self, detector):
+        for detected in _detections(detector, "LICENSE", self.UNKNOWN_LICENSE_TEXT):
+            if detected.detection_method == "regex":
+                assert detected.confidence <= 0.6, (
+                    f"{detected.spdx_id} asserted at {detected.confidence} from a "
+                    f"pattern match on text no tier could identify"
+                )
+
+    def test_regex_fallback_cannot_outrank_a_text_match(self, detector):
+        """Whatever it reports must not look like an identification."""
+        detections = _detections(detector, "LICENSE", self.UNKNOWN_LICENSE_TEXT)
+        regex_hits = [d for d in detections if d.detection_method == "regex"]
+        if regex_hits:
+            assert max(d.confidence for d in regex_hits) < 0.85, (
+                "a regex fallback outranks a keyword identification"
+            )


### PR DESCRIPTION
Fixes #98.

1.7.1 fixed a class of false positives (#90, #91) and created a larger class of false negatives. For a compliance tool, a GPL file reported as carrying no license is worse than the false positives that were fixed.

All rows verified by running the same input against 1.7.0, 1.7.2, and this branch.

| Input | 1.7.0 | 1.7.2 (shipped) | This PR |
|---|---|---|---|
| Canonical FSF GPL-2 header | `GPL-2.0-only` | **nothing** | `GPL-2.0-or-later` |
| Canonical FSF GPL-3 header | `GPL-3.0-only` | **nothing** | `GPL-3.0-or-later` |
| GPL header + OpenSSL linking exception | `GPL-3.0-only` | **nothing** | `GPL-3.0-or-later` |
| `"licensed under GPL2"` | `GPL-2.0-only` | **nothing** | `GPL-2.0-only` |
| zlib grant containing "compatibility" | `Zlib` | **nothing** | `Zlib` |
| Sleepycat LICENSE (copyleft) | `Sleepycat` 0.99 | **`BSD-3-Clause` @ 1.00** | `Sleepycat` 0.86 |
| CECILL-2.1 LICENSE (copyleft) | `CECILL-2.1` 1.00 | **`GPL-3.0-only` @ 1.00** | `CECILL-2.1` 0.93 |
| LGPL-2.1 mention | `GPL-2.0-only` + `LGPL-2.1-only` | same | `LGPL-2.1-only` only |

The FSF header now resolves to `-or-later`, which is what "or (at your option) any later version" actually grants — more accurate than 1.7.0.

## Changes

**Version regex.** Now reads the FSF phrasing (version attached to *the License*, not to *GPL*), the separator-less `GPL2` form, and treats a trailing "any later version" as an `-or-later` grant.

**Linking exceptions no longer suppress their own grant.** The guard still stops `OpenSSL` being asserted for the carved-out library, but never applies to GNU-family matches — a file carrying a linking exception is by definition licensed under the copyleft license granting it. Paragraph detection now treats a line of bare comment markers as a break, since `\n\n` never occurs inside a `/* ... */` block.

**`compatib` narrowed** to require a license name alongside it, so ordinary English "compatibility" in a grant sentence no longer suppresses it. The PSF-stack case that motivated the guard stays suppressed.

**Fuzzy tier may assert an unambiguous match.** Requiring corroboration silenced it for the ~657 of 703 licenses with no bundled text, and the regex tier filled the vacuum at confidence 1.0. It may now also assert a candidate that no other license comes near — its inability to separate near neighbours does not apply when there are none.

The margin is **measured, not chosen**: across the #90 confusions the wrong answer never leads by more than 13 (12, 13, 3, 2, 1); across licenses the tier gets right but cannot corroborate the correct answer leads by 20 or more (43, 39, 26, 20). Nothing falls between.

**Regex fallback capped at 0.6**, below the keyword tier, when reached after every text tier declined — it describes an unrecognized document rather than identifying one.

## Verification

- The #90 near-neighbour confusions all still decline. The #90/#91 corpus passes unchanged.
- **69 real package license files: not one license identity changes.** Thirteen regex detections drop from 1.0 to 0.6, which is the intended correction. (Some previously-invisible regex evidence now appears, because dedup keys on confidence and a 1.0 regex hit used to collapse into a 1.0 tag hit.)
- 12 new tests, **7 of which fail against 1.7.1**. Suite: 139 passing.

## Why the previous verification missed this

It asserted that licenses which *should* resolve still did — which cannot detect a license that stopped resolving — and every fixture was a full LICENSE file from the minority of licenses with bundled text. No source headers at all. `tests/test_false_negatives.py` covers those gaps directly.