### PR TITLE
Release 1.7.5: require a real corroborator before accepting borderline matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to osslili will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.5] - 2026-08-11
+
+Recommended upgrade for anyone on 1.7.4 that does **not** have `python-tlsh`
+installed — which is the default, since it builds from C and needs a compiler.
+
+### Fixed
+- **Borderline similarity matches were accepted without any corroboration when `python-tlsh` is absent.** 1.7.4 opened the band between the similarity floor (`0.90`) and `similarity_threshold` to matches that TLSH corroborates. But `confirm_license_match()` answers `True` when it cannot check, so with no TLSH installed the corroboration requirement silently became a rubber stamp
+  - A Sleepycat license file was reported as `BSD-3-Clause` at **0.91** — the texts really are that similar, and the clauses that differ are what makes Sleepycat copyleft. In 1.7.3 the same file produced a low-confidence `0.60` pattern guess, so 1.7.4 made a wrong answer look credible
+  - The band is now opened only when a corroborator is actually available. Installs with `python-tlsh` keep everything 1.7.4 added; installs without it get 1.7.3's stricter behaviour
+  - New `TLSHDetector.can_confirm` distinguishes "confirmed" from "could not check"
+
+### Documentation
+- **`python-tlsh` is now documented as recommended**, in the README, the site overview, and the detection page, with what is actually lost without it — tier 2 does not run, and tier 1's borderline band stays shut. Includes the `gcc python3-dev` prerequisite for slim container images
+
 ## [1.7.4] - 2026-08-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,8 +21,24 @@ substantiate — an identification it cannot back up is dropped rather than gues
 pip install osslili
 ```
 
-Requires Python 3.9 or later. Installing `python-tlsh` alongside it enables an
-additional fuzzy matching tier for reformatted license texts.
+Requires Python 3.9 or later.
+
+**Recommended:** install `python-tlsh` alongside it.
+
+```bash
+pip install osslili python-tlsh
+```
+
+It is optional, but detection is measurably better with it. It powers the fuzzy
+matching tier, which identifies license texts too reformatted for exact or
+similarity matching — several licenses are detectable only this way — and
+corroborates borderline similarity matches so they can be reported at all.
+Without a corroborator that band stays closed, because accepting an unverified
+match there means reporting one license as another it merely resembles, and
+copyleft and permissive licenses are often a single clause apart.
+
+`python-tlsh` builds from C and needs a compiler; on slim container images run
+`apt-get install -y gcc python3-dev` first.
 
 For development:
 

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -40,6 +40,27 @@ Tiers run in order, and the first one to produce a match wins.
 | 0 | `hash` | SHA-256 / MD5 of the normalized text against a table of known license hashes. An exact match is reported at confidence `1.0`. |
 | 1 | `dice-sorensen` | Character-bigram Dice-Sørensen similarity against the license corpus. Tolerates reformatting, differing copyright lines, and minor edits. |
 | 2 | `tlsh` | Fuzzy hashing, for texts too modified for tier 1. Requires the optional `python-tlsh` package. |
+
+{: .note }
+> **Install `python-tlsh`.** Without it, tier 2 does not run *and* tier 1 loses
+> its borderline band, described below — so detection is meaningfully weaker.
+> See [Overview]({{ site.baseurl }}/).
+
+### What tier 1 accepts
+
+A similarity score at or above `similarity_threshold` (default `0.97`) is
+accepted outright. Between that and a floor of `0.90`, the match is only
+accepted if the fuzzy tier corroborates it.
+
+That band is where licenses like a reformatted BSD-3-Clause file live — real
+matches that a strict threshold would throw away. But it is also where
+near-identical licenses collide: a Sleepycat license file scores `0.906` against
+BSD-3-Clause, and Sleepycat is copyleft while BSD-3-Clause is not.
+
+So the band is only opened when something can actually corroborate. **With no
+`python-tlsh` installed there is no corroborator, and the band stays shut** —
+osslili reports less rather than reporting a license that the text merely
+resembles.
 | 3 | `regex` | Pattern matching for license references and headers that are not full texts. |
 
 Normalization strips copyright holder lines before comparison, so the same license

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,11 +26,30 @@ pip install osslili
 
 osslili needs Python 3.9 or later.
 
-Fuzzy hash matching is optional. Installing `python-tlsh` enables an extra matching
-tier for license texts that have been reformatted or lightly edited:
+### Recommended: install `python-tlsh` too
 
 ```bash
 pip install osslili python-tlsh
+```
+
+`python-tlsh` is optional, but **detection is measurably better with it** and we
+recommend installing it for any compliance use.
+
+It powers the fuzzy matching tier, which does two jobs nothing else can. It
+identifies license texts that have been reformatted or lightly edited past what
+exact and similarity matching recognise — several licenses are detectable *only*
+this way. And it corroborates borderline similarity matches, which lets those be
+reported at all: without a corroborator the borderline band is closed, because
+accepting an unverified match there means reporting one license as another it
+merely resembles. Copyleft and permissive licenses are often only a clause apart.
+
+Without it osslili still works and still refuses to guess — it reports less.
+
+`python-tlsh` builds from C, so it needs a compiler. On a slim container image
+install build tools first:
+
+```bash
+apt-get install -y gcc python3-dev && pip install python-tlsh
 ```
 
 To work on osslili itself, install it from a checkout in editable mode:

--- a/osslili/__init__.py
+++ b/osslili/__init__.py
@@ -13,7 +13,7 @@ if os.environ.get('OSLILI_DEBUG') != '1':
     except ImportError:
         pass
 
-__version__ = "1.7.4"
+__version__ = "1.7.5"
 
 from .core.generator import LicenseCopyrightDetector
 from .core.models import (

--- a/osslili/detectors/license_detector.py
+++ b/osslili/detectors/license_detector.py
@@ -2324,10 +2324,21 @@ class LicenseDetector:
 
             # At or above the configured similarity threshold the score speaks
             # for itself. Below it, down to the floor, the match must be
-            # corroborated by TLSH before it is accepted — which is what makes
-            # the band between the two usable rather than simply discarded.
-            if best_score >= self.config.similarity_threshold or \
-                    self.tlsh_detector.confirm_license_match(text, best_match):
+            # corroborated before it is accepted — which is what makes the band
+            # between the two usable rather than simply discarded.
+            #
+            # Corroboration needs TLSH, which is an optional dependency that
+            # needs a C toolchain, so a plain install usually does not have it.
+            # Without it there is nothing to corroborate with, and accepting the
+            # band anyway is how a Sleepycat license file came to be reported as
+            # BSD-3-Clause at 0.91 — the two texts really are that similar, and
+            # the clauses that differ are the whole point. So when no confirmer
+            # is available the band is not opened at all.
+            corroborated = (
+                self.tlsh_detector.can_confirm
+                and self.tlsh_detector.confirm_license_match(text, best_match)
+            )
+            if best_score >= self.config.similarity_threshold or corroborated:
                 license_info = self.spdx_data.get_license_info(best_match)
                 category, match_type = self._categorize_license(
                     file_path, DetectionMethod.DICE_SORENSEN.value

--- a/osslili/detectors/tlsh_detector.py
+++ b/osslili/detectors/tlsh_detector.py
@@ -355,19 +355,36 @@ class TLSHDetector:
             logger.error(f"Error in TLSH detection: {e}")
             return None
 
+    @property
+    def can_confirm(self) -> bool:
+        """Whether corroboration is actually available.
+
+        ``python-tlsh`` is an optional dependency that needs a C toolchain to
+        build, so a plain ``pip install osslili`` commonly has no TLSH at all.
+        Callers that treat corroboration as a safety requirement must check
+        this: ``confirm_license_match`` answers True when it cannot check, so a
+        caller that only looks at its return value gets a rubber stamp rather
+        than a confirmation.
+        """
+        return TLSH_AVAILABLE and self._initialized
+
     def confirm_license_match(self, text: str, license_id: str, threshold: int = 100) -> bool:
         """
         Confirm a license match using TLSH.
-        
+
+        Returns True when it cannot check — an unavailable confirmer must not
+        veto an otherwise good match. Check :attr:`can_confirm` first if a real
+        confirmation is required.
+
         Args:
             text: Text to check
             license_id: SPDX license ID to confirm
             threshold: Maximum TLSH distance for confirmation (default 100)
-            
+
         Returns:
-            True if confirmed, False otherwise
+            True if confirmed or unable to check, False if refuted
         """
-        if not TLSH_AVAILABLE or not self._initialized:
+        if not self.can_confirm:
             return True  # Can't confirm, assume valid
         
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "osslili"
-version = "1.7.4"
+version = "1.7.5"
 description = "Open Source License Identification Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_false_negatives.py
+++ b/tests/test_false_negatives.py
@@ -312,3 +312,51 @@ covered by the above license.
             if detected.detection_method == "dice-sorensen":
                 assert 0.9 <= detected.confidence < 0.97
                 return
+
+
+class TestCorroborationRequiresAConfirmer:
+    """The weaker-score band must stay shut when nothing can corroborate.
+
+    ``python-tlsh`` is optional and needs a C toolchain, so a plain
+    ``pip install osslili`` usually has no TLSH. ``confirm_license_match``
+    answers True when it cannot check — sensible on its own, but a caller
+    treating that as corroboration gets a rubber stamp. Accepting the band on
+    that basis reported a Sleepycat license file as BSD-3-Clause at 0.91: the
+    texts really are that similar, and the clauses that differ are the point.
+    """
+
+    @pytest.fixture
+    def detector_without_tlsh(self, monkeypatch):
+        import osslili.detectors.tlsh_detector as tlsh_module
+        monkeypatch.setattr(tlsh_module, "TLSH_AVAILABLE", False)
+        det = LicenseDetector(Config())
+        _ = det.spdx_data.licenses
+        assert not det.tlsh_detector.can_confirm
+        return det
+
+    def test_band_stays_shut_without_a_confirmer(self, detector_without_tlsh):
+        """A sub-threshold similarity match is not accepted unverified."""
+        text = (
+            TestSimilarityThresholdGate.BSD_3_SLIGHTLY_REWORDED
+            + TestSimilarityThresholdGate.TRAILER
+        )
+        for detected in _detections(detector_without_tlsh, "LICENSE", text):
+            if detected.detection_method == "dice-sorensen":
+                assert detected.confidence >= detector_without_tlsh.config.similarity_threshold, (
+                    f"accepted an uncorroborated {detected.confidence} match with "
+                    f"no confirmer available"
+                )
+
+    def test_strong_matches_are_unaffected(self, detector_without_tlsh):
+        """Licenses that match outright must not need a confirmer at all."""
+        ids = _ids(
+            detector_without_tlsh,
+            "LICENSE",
+            TestSimilarityThresholdGate.BSD_3_SLIGHTLY_REWORDED,
+        )
+        assert "BSD-3-Clause" in ids, f"got {ids}"
+
+    def test_can_confirm_reports_availability(self, detector):
+        """The flag must reflect reality where TLSH *is* installed."""
+        import osslili.detectors.tlsh_detector as tlsh_module
+        assert detector.tlsh_detector.can_confirm == tlsh_module.TLSH_AVAILABLE


### PR DESCRIPTION
**Recommended upgrade for anyone on 1.7.4 without `python-tlsh`** — which is the default, since it builds from C and needs a compiler.

## The bug

1.7.4 opened the similarity band between the `0.90` floor and `similarity_threshold` to matches the fuzzy tier corroborates. But `confirm_license_match()` returns `True` when it *cannot* check — correct in isolation, since an unavailable confirmer shouldn't veto a good match — so treating that as corroboration is a rubber stamp.

`python-tlsh` is optional and needs a C toolchain, so a plain `pip install osslili` has no TLSH. That's the common case, and exactly where 1.7.4's safety net doesn't exist.

| Sleepycat license file | Result |
|---|---|
| 1.7.3, no TLSH | `BSD-3-Clause` @ 0.60 — wrong, low confidence |
| **1.7.4, no TLSH** | **`BSD-3-Clause` @ 0.91** — wrong, looks credible |
| 1.7.5, no TLSH | `BSD-3-Clause` @ 0.60 |
| 1.7.5, with TLSH | `Sleepycat` ✓ |

Sleepycat is copyleft; BSD-3-Clause is not. The texts genuinely score 0.906 against each other — the clauses that differ are the entire point.

## Fix

The band opens only when a corroborator is actually available. New `TLSHDetector.can_confirm` distinguishes *confirmed* from *could not check*.

- **With `python-tlsh`:** everything 1.7.4 added is kept — protobuf 0.957 and multiprocess 0.932 still resolve, Sleepycat resolves correctly
- **Without it:** 1.7.3's stricter behaviour
- **Licenses that match outright:** unaffected either way (MIT, BSD-3-Clause, Apache-2.0 all still 1.00)

## How it was found

By installing the published package in a clean container with no build tools — what a partner actually gets from `pip install osslili`. My development environment has `python-tlsh`, so none of this was reachable locally.

## Docs

`python-tlsh` is now documented as **recommended** in the README, site overview, and detection page, with what's lost without it and the `gcc python3-dev` prerequisite for slim images.

Suite: 157 passing.