### PR TITLE
Correct the python-tlsh build requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ Without a corroborator that band stays closed, because accepting an unverified
 match there means reporting one license as another it merely resembles, and
 copyleft and permissive licenses are often a single clause apart.
 
-`python-tlsh` builds from C and needs a compiler; on slim container images run
-`apt-get install -y gcc python3-dev` first.
+`python-tlsh` builds from C++ and needs a compiler. On slim container images
+install one first:
+
+```bash
+apt-get install -y g++
+```
 
 For development:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,11 +45,11 @@ merely resembles. Copyleft and permissive licenses are often only a clause apart
 
 Without it osslili still works and still refuses to guess — it reports less.
 
-`python-tlsh` builds from C, so it needs a compiler. On a slim container image
-install build tools first:
+`python-tlsh` builds from C++, so it needs a compiler. On a slim container image
+install one first — note it is `g++`, not `gcc`:
 
 ```bash
-apt-get install -y gcc python3-dev && pip install python-tlsh
+apt-get install -y g++ && pip install python-tlsh
 ```
 
 To work on osslili itself, install it from a checkout in editable mode:


### PR DESCRIPTION
The install instructions I added in #103 said `gcc python3-dev`. TLSH is **C++**, so the build invokes `g++` and fails on an image that only has `gcc`:

```
error: [Errno 2] No such file or directory: 'g++'
```

Verified in a clean `python:3.12-slim` container. With `g++` installed, `python-tlsh` builds and all 8 fixtures resolve — including `Sleepycat` and `CECILL-2.1`, which need the fuzzy tier:

| | no tlsh | + tlsh |
|---|---|---|
| MIT / BSD-3-Clause / Apache-2.0 / GPL-3.0 / Python-2.0 | ok | ok |
| Sleepycat | `BSD-3-Clause` 0.60 | **`Sleepycat`** 0.88 |
| CECILL-2.1 | `GPL-2.0-only` 0.75 | **`CECILL-2.1`** 0.94 |
| GPL-2 source header (deep) | ok | ok |

Documentation only; no code change, so no release needed — the site rebuilds from `main`. The PyPI README picks it up on the next release.